### PR TITLE
fix(data): corregir datos de Hospital Veterinario Medical Care con confirmación directa del establecimiento

### DIFF
--- a/src/content/clinicas/hospital-vet-medical-care-heredia.md
+++ b/src/content/clinicas/hospital-vet-medical-care-heredia.md
@@ -6,9 +6,9 @@ direccion: "De la esquina suroeste de la Escuela Rafael Moya, 25 m oeste, Edific
 telefono1: "2262-6826"
 telefono2: ""
 whatsapp: "8639-6793"
-horarioTexto: "L-D 9am-9pm jornada continua"
-categoriaHorario: "Cierra después 21h"
-emergencias24h: false
+horarioTexto: "24/7 todos los días"
+categoriaHorario: "24/7 Emergencias"
+emergencias24h: true
 atiendeExoticos: true
 cirugiaEmergencia: true
 web: "hospitalveterinariomedicalcare.com"
@@ -16,23 +16,23 @@ facebook: ""
 instagram: ""
 slug: "hospital-vet-medical-care-heredia"
 estado: "verificado"
-copyDiferenciador: "Horario continuo hasta las 9pm todos los días. Cirugía, laboratorio, internamiento y parqueo privado. Abrió en 2021."
+copyDiferenciador: "Hospital veterinario abierto 24/7 con médico veterinario presencial en sitio. Internamiento, cirugía, laboratorio y parqueo privado. Cuenta con hotel exclusivamente para gatos. Abrió en 2021."
 confidence_score: "high"
 record_status: "VERIFIED"
-emergency_tier: "Tier B"
-last_verified: ""
+emergency_tier: "Tier A"
+last_verified: "2026-09-01"
 phone_verified: false
 address_verified: false
-schedule_verified: false
+schedule_verified: true
 emergency_verified: true
 has_surgery: true
-has_hospitalization: false
-verification_source: ""
-overnight_doctor_present: false
+has_hospitalization: true
+verification_source: "Confirmación directa del establecimiento por correo electrónico"
+overnight_doctor_present: true
 latitude: 9.9997
 longitude: -84.1164
 waze_url: "https://waze.com/ul?q=Hospital%20Veterinario%20Medical%20Care%20Heredia%20centro%20Heredia%20Costa%20Rica&navigate=yes"
 maps_url: "https://www.google.com/maps/search/?api=1&query=Hospital%20Veterinario%20Medical%20Care%20Heredia%20centro%20Heredia%20Costa%20Rica"
 ---
 
-Horario continuo hasta las 9pm todos los días. Cirugía, laboratorio, internamiento y parqueo privado. Abrió en 2021.
+Hospital veterinario abierto 24/7 con médico veterinario presencial en sitio. Internamiento, cirugía, laboratorio y parqueo privado. Cuenta con hotel exclusivamente para gatos. Abrió en 2021.

--- a/tests/e2e/semantic-copy.spec.ts
+++ b/tests/e2e/semantic-copy.spec.ts
@@ -18,7 +18,7 @@ const AFIRMACIONES_PROHIBIDAS = [
 ];
 
 // Fichas representativas de cada combinación de estados.
-const FICHA_INCIDENTE = '/clinica/hospital-vet-medical-care-heredia/';   // Tier B, casi todo false, VERIFIED sin evidencia
+const FICHA_INCIDENTE = '/clinica/hems-una-heredia/';                    // Tier B, casi todo false, VERIFIED sin evidencia
 const FICHA_SIN_CAPACIDADES = '/clinica/atlantic-vet-guapiles/';          // Tier C, todos los booleanos en false
 const FICHA_CONFIRMADA = '/clinica/la-vete-escazu/';                      // Tier A, todo confirmado + fecha y fuente
 const FICHA_SIN_EVIDENCIA = '/clinica/agromedica-escazu/';                // Tier A confirmado, sin fecha ni fuente


### PR DESCRIPTION
Actualización puntual de datos de `hospital-vet-medical-care-heredia` con información confirmada directamente por el establecimiento. Dos archivos, 12 inserciones / 12 eliminaciones.

## Origen

El hospital escribió por correo el **2026-09-01** y confirmó que opera 24 horas los 7 días, con médico veterinario permanente y presencial en sitio, internamiento, y hotel exclusivamente para gatos. Eligió explícitamente mantener su ficha en Vet24 y pidió que actualizáramos la información con los datos que nos dio.

La ficha registraba `L-D 9am-9pm jornada continua`, que ya no corresponde. La fuente prioritaria de esta corrección es la confirmación directa del establecimiento. Hay corroboración pública parcial: Facebook aparece como «Always open», publicaciones recientes asociadas a sus redes muestran turnos nocturnos, y La Gaceta respalda cirugía, laboratorio e internamiento. Siguen circulando fuentes secundarias antiguas que reproducen el horario viejo.

## Cambios en la ficha

| Campo | Antes | Después |
|---|---|---|
| `horarioTexto` | `L-D 9am-9pm jornada continua` | `24/7 todos los días` |
| `categoriaHorario` | `Cierra después 21h` | `24/7 Emergencias` |
| `emergencias24h` | `false` | `true` |
| `overnight_doctor_present` | `false` | `true` |
| `has_hospitalization` | `false` | `true` |
| `emergency_tier` | `Tier B` | `Tier A` |
| `schedule_verified` | `false` | `true` |
| `last_verified` | `""` | `2026-09-01` |
| `verification_source` | `""` | `Confirmación directa del establecimiento por correo electrónico` |
| `copyDiferenciador` + cuerpo Markdown | horario viejo | descripción de capacidades reales |

`horarioTexto` usa el formato canónico que ya emplean otras fichas 24/7 del dataset (`hospital-vet-santamaria-alajuela`, `petopia-tibas`). No se introdujo convención nueva.

**Tier A.** Cumple los cuatro criterios documentados, verificados literalmente después del cambio: `emergency_verified`, `overnight_doctor_present`, `has_hospitalization` y `has_surgery`, los cuatro en `true`. No se tocó ninguna regla global de Tier.

**Copy final:**

> Hospital veterinario abierto 24/7 con médico veterinario presencial en sitio. Internamiento, cirugía, laboratorio y parqueo privado. Cuenta con hotel exclusivamente para gatos. Abrió en 2021.

Sin mención de Tier y sin lenguaje promocional.

## Campos conservados a propósito

- **`cirugiaEmergencia: true`**, su valor previo. El campo alimenta el bloque «Cirugía Urgencia» vía `capabilityStatus(cirugiaEmergencia, 'SÍ Disponible')`. No se derivó de `has_surgery` ni se reinterpretó como «cirugía de emergencia 24/7».
- **`phone_verified: false`** y **`address_verified: false`**. Un correo no verifica el teléfono ni la dirección.
- **`record_status: VERIFIED`** y **`confidence_score: high`**, ya vigentes. La confirmación de algunos atributos no convierte la ficha entera en verificada.
- **`hotelMascotas` sin declarar** (`false`). Ver más abajo.

## Hotel para gatos y la limitación del modelo

`hotelMascotas` es un `boolean` y no puede expresar que el servicio es solo para gatos. Ponerlo en `true` haría que la card, el badge, el filtro global «Hotel para mascotas» y el JSON-LD afirmaran hotel general, lo que implica perros y sobreafirma frente a lo confirmado. Se mantuvo el booleano como estaba y el hecho se expresa en el copy.

Consecuencia conocida: el `FAQPage` de la ficha sigue emitiendo «no tiene servicio de hotel para mascotas confirmado en la información pública revisada» mientras el copy dice que sí hay hotel para gatos. Es una contradicción en contenido indexable que **no tiene solución dentro de la ficha** — hace falta un atributo con alcance por especie. Queda registrada como P1 en Gunz-cop/Vet24-cr#5 y deliberadamente fuera de este PR.

## Cambio de fixture en los tests

`tests/e2e/semantic-copy.spec.ts` usaba esta ficha como `FICHA_INCIDENTE`, descrita en el propio código como «Tier B, casi todo false, VERIFIED sin evidencia». Corregidos los datos, la ficha deja de representar esa combinación y cuatro aserciones quedaron sin sujeto válido.

La constante se repunta a `hems-una-heredia`, gemelo estructural exacto del caso anterior:

```
Tier B · VERIFIED · last_verified "" · verification_source ""
emergencias24h false · overnight false · hospitalization false · hotelMascotas ausente
```

Se verificaron las siete aserciones que dependen de la constante y todas se sostienen con HEMS, incluida «una fuente vacía no se rellena con Llamada directa». **Ninguna aserción se relajó ni se eliminó**: la cobertura de regresión del hotfix semántico se conserva íntegra, solo cambia el ejemplar.

## Validación

|  | main (línea base medida) | esta rama |
|---|---|---|
| Unit | 23/23 | 23/23 |
| E2E pasan | 56 | 56 |
| E2E fallan | 16 | 16 |

`semantic-copy` aislada: **17/17**. Los 16 fallos son preexistentes e idénticos en ambas corridas (mapa Leaflet y geolocalización, con el CDN y los tiles bloqueados en el entorno de pruebas); se comprobó reconstruyendo y ejecutando la suite completa sobre `main`. **Cero regresiones nuevas.**

Build limpio. Inspección del HTML generado para la ficha: cero ocurrencias de `9am-9pm`, `9 a.m.`, `9pm`, `No confirmado como 24/7`, `Sin servicio 24/7 confirmado`, `Emergencia Parcial`, `Cierra tarde` ni `Tier B`. El bloque de advertencia `#warning-diurnal-alert` ya no se emite.

Estados renderizados: médico nocturno ✓ *Confirmado Permanente*, hospitalización ✓ *Disponible*, emergencias 24/7 *Confirmada en esta ficha* / *SÍ Disponible*, Tier **A · Emergencia Real 24/7**. Los dos `No confirmado` restantes son ambos del hotel, intencionales.

Contenido indexable: JSON-LD `openingHoursSpecification` = Lun–Dom 00:00–23:59; `description` = copy nuevo; FAQ de horario = «24/7 todos los días»; meta description y `og:description` = plantilla 24/7 del sitio.

Trazabilidad renderizada: `📅 2026-09-01 · Confirmación directa del establecimiento por correo electrónico`, con badge *Con fuente y fecha de revisión*. Ninguna cadena «llamada», «telefónica» ni «auditoría» asociada al registro.

Vistas: card en `/` y `/provincia/heredia/` con `data-247="true"`, `data-schedule="24h"`, `data-tier="Tier A"`. Esto la hace entrar en los filtros **Solo 24/7** y **Abierto ahora**, y arrastra mapa y fallback SOS, que leen los mismos atributos.

## Nota para revisión posterior

`tests/e2e/tier4-workloads.spec.ts:8` espera que la primera card sea *Ramírez* con geolocalización en Heredia centro más filtro «Solo 24/7». Medical Care está a 403 m de ese punto y Ramírez a 2 810 m, así que la aserción probablemente quedó obsoleta — y de ser así sería un cambio de comportamiento correcto, no una regresión. No se pudo comprobar: ese test ya falla en la línea base por falta de geolocalización y mapa en el entorno. **No se tocó**, se revisa cuando la suite de mapa pueda correr de verdad.

## Alcance

Solo la ficha, más una línea de fixture. No se tocó el modelo de datos, la UI global, los tooltips, la explicación de Tier, los filtros, las reglas de verificación, ni ninguna otra ficha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sU79KByjjjzfdsHJPRajH

---
_Generated by [Claude Code](https://claude.ai/code/session_016sU79KByjjjzfdsHJPRajH)_