### PR TITLE
Quitar nota interna sobre falta de sitio web en ficha de Medical Care Heredia

### DIFF
--- a/src/content/clinicas/hospital-vet-medical-care-heredia.md
+++ b/src/content/clinicas/hospital-vet-medical-care-heredia.md
@@ -39,7 +39,6 @@ verification_notes:
   - "Especies atendidas: pequeños animales de compañía - perros, gatos, conejos, erizos, hámsters, cuilos y otros."
   - "No atiende animales de granja ni peces."
   - "Hotel exclusivo para gatos, requiere reserva previa."
-  - "No tienen sitio web propio (no fue rentable); atención por Facebook e Instagram."
   - "Dirección confirmada: Heredia centro, 25 m oeste de la Escuela Moya Murillo, contiguo a la sucursal del INS."
 verification_source: "Confirmación directa del establecimiento por correo electrónico y llamada telefónica"
 overnight_doctor_present: true


### PR DESCRIPTION
## Summary
- Se elimina de `verification_notes` la observación sobre que Medical Care Heredia no tiene sitio web propio "porque no fue rentable" — a pedido del cliente, no debe quedar registrada esa información.

## Test plan
- [x] `npx astro sync` corre sin errores de validación de schema contra `src/content.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LR9Nru2bsQc2RLm1fvmJrD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LR9Nru2bsQc2RLm1fvmJrD)_