### PR TITLE
Hotfix SEO: metadata de fichas sin datos operativos volátiles

### DIFF
--- a/src/lib/metaDescription.ts
+++ b/src/lib/metaDescription.ts
@@ -1,0 +1,172 @@
+/**
+ * Hotfix SEO — metadata sin datos operativos volátiles.
+ *
+ * PROBLEMA: las meta descriptions de las fichas se construían a partir del
+ * estado operativo de la clínica (horario textual, emergencias 24/7, promesas
+ * de atención inmediata). Cuando ese dato cambia, la página se corrige el mismo
+ * día pero buscadores, cachés y sistemas de IA pueden seguir sirviendo la
+ * descripción vieja durante días. Un snippet obsoleto de horario es una
+ * afirmación falsa sobre disponibilidad médica.
+ *
+ * REGLA: la meta description (y sus equivalentes sociales / JSON-LD) se
+ * construye únicamente con atributos relativamente estables de la ficha:
+ * nombre, zona, provincia y servicios/capacidades registrados. Nada que
+ * dependa de la hora actual, del horario declarado ni de una promesa de
+ * disponibilidad.
+ *
+ * Esto NO cambia el contenido visible de la ficha ni la lógica funcional de
+ * horarios, filtros o «Abierto ahora»: el horario sigue publicado en la página
+ * y en `openingHoursSpecification` del JSON-LD, que es el lugar correcto para
+ * el dato factual y estructurado.
+ */
+
+export interface ClinicMetaInput {
+  nombre: string;
+  zona: string;
+  provincia: string;
+  copyDiferenciador?: string;
+  atiendeExoticos?: boolean;
+  atiendeGranja?: boolean;
+  atiendePeces?: boolean;
+  cirugiaEmergencia?: boolean;
+  has_surgery?: boolean;
+  has_hospitalization?: boolean;
+  hotelMascotas?: boolean;
+  hotelVerificacion?: string;
+}
+
+/**
+ * Patrones que NO pueden aparecer en metadata: quedan obsoletos rápido y
+ * sobreviven en cachés e índices como si siguieran siendo ciertos.
+ */
+export const VOLATILE_METADATA_PATTERNS: { name: string; pattern: RegExp }[] = [
+  { name: "hora con am/pm", pattern: /\b\d{1,2}(?::\d{2})?\s*(?:a\.?\s?m\.?|p\.?\s?m\.?)/i },
+  { name: "hora con formato 24h", pattern: /\b\d{1,2}(?::\d{2})\s*(?:h(?:rs?)?)?\b/i },
+  { name: "hora abreviada (21h)", pattern: /\b\d{1,2}\s*h(?:rs?)?\b/i },
+  { name: "rango horario", pattern: /\b\d{1,2}\s*[-–a]\s*\d{1,2}\s*(?:a\.?\s?m\.?|p\.?\s?m\.?|h)/i },
+  { name: "disponibilidad 24/7", pattern: /\b24\s*[/\-x]\s*7\b/i },
+  { name: "24 horas", pattern: /\b24\s*(?:horas|hrs)\b/i },
+  { name: "días de la semana", pattern: /\b(?:l-d|l-v|lun(?:es)?\s*(?:a|-)\s*(?:dom|vie|sáb|sab))/i },
+  { name: "jornada continua", pattern: /jornada continua|horario continuo/i },
+  { name: "horario", pattern: /\bhorarios?\b/i },
+  { name: "estado de apertura", pattern: /\babiert[oa]s?\b|\bcerrad[oa]s?\b|\babre\b|\bcierra\b/i },
+  { name: "disponibilidad inmediata", pattern: /de inmediato|inmediatamente|ahora mismo|llama ahora|atención inmediata|disponibilidad inmediata|al instante/i },
+  { name: "guardia / nocturno", pattern: /\bde guardia\b|\bnocturn[oa]s?\b|\btoda la noche\b|\bhoy\b/i },
+];
+
+/** Devuelve los nombres de los patrones volátiles encontrados en un texto. */
+export function findVolatileMetadata(text: string): string[] {
+  return VOLATILE_METADATA_PATTERNS.filter(({ pattern }) => pattern.test(text)).map(({ name }) => name);
+}
+
+const normalize = (text: string) =>
+  text.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+
+interface ServiceRule {
+  label: string;
+  match: (copy: string, data: ClinicMetaInput) => boolean;
+}
+
+/**
+ * Servicios clínicos estables. Se detectan desde los booleanos de la ficha o
+ * desde `copyDiferenciador` con una lista blanca de términos: nunca se infiere
+ * un servicio que la ficha no mencione, y la ausencia de evidencia jamás se
+ * convierte en afirmación negativa (no se escribe «no hace cirugía»).
+ */
+const CORE_SERVICES: ServiceRule[] = [
+  { label: "cirugía", match: (c, d) => d.has_surgery === true || d.cirugiaEmergencia === true || /cirug|quirurgic/.test(c) },
+  { label: "internamiento", match: (c, d) => d.has_hospitalization === true || /internamiento|hospitalizaci/.test(c) },
+  { label: "laboratorio", match: (c) => /laboratorio/.test(c) },
+  { label: "imágenes médicas", match: (c) => /imagenes medicas|rayos x|radiograf|ultrasonido|ecograf/.test(c) },
+  { label: "odontología", match: (c) => /odontolog|limpieza dental|limpiezas dentales|dental/.test(c) },
+  { label: "farmacia veterinaria", match: (c) => /farmacia/.test(c) },
+  { label: "vacunación", match: (c) => /vacuna/.test(c) },
+  { label: "estética canina", match: (c) => /peluqueria|grooming|estetica/.test(c) },
+];
+
+/** Rasgos diferenciadores estables: lo que distingue una ficha de las demás. */
+const DIFFERENTIATOR_SERVICES: ServiceRule[] = [
+  {
+    label: "hotel exclusivo para gatos",
+    match: (c, d) => hasHotel(d) && /(hotel|hospedaje)[^.]{0,60}(exclusiv|solo)[^.]{0,20}gat/.test(c),
+  },
+  { label: "hotel para mascotas", match: (c, d) => hasHotel(d) },
+  { label: "atención de exóticos", match: (c, d) => d.atiendeExoticos === true },
+  { label: "animales de granja", match: (c, d) => d.atiendeGranja === true },
+  { label: "peces ornamentales", match: (c, d) => d.atiendePeces === true },
+  { label: "servicio a domicilio", match: (c) => /a domicilio/.test(c) },
+  { label: "ambulancia veterinaria", match: (c) => /ambulancia/.test(c) },
+  { label: "cremación", match: (c) => /cremacion/.test(c) },
+  { label: "tienda de mascotas", match: (c) => /tienda de mascotas|pet shop/.test(c) },
+];
+
+function hasHotel(d: ClinicMetaInput): boolean {
+  return d.hotelMascotas === true && d.hotelVerificacion !== "no-confirmado";
+}
+
+const pickServices = (rules: ServiceRule[], copy: string, data: ClinicMetaInput) =>
+  rules.filter((rule) => rule.match(copy, data)).map((rule) => rule.label);
+
+/** Une una lista en castellano: «a, b y c». */
+function joinEs(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  return `${items.slice(0, -1).join(", ")} y ${items[items.length - 1]}`;
+}
+
+const capitalize = (text: string) => text.charAt(0).toUpperCase() + text.slice(1);
+
+/** Ubicación legible sin repetir la provincia cuando ya está en la zona. */
+export function buildLocation(zona: string, provincia: string): string {
+  const z = normalize(zona);
+  const p = normalize(provincia);
+  return z === p || z.includes(p) ? zona : `${zona}, ${provincia}`;
+}
+
+const MAX_LENGTH = 165;
+
+/**
+ * Construye la meta description de una ficha con datos estables.
+ *
+ * Formato: «{nombre} en {zona}, {provincia}. {servicios}. Consulta dirección,
+ * teléfonos y servicios en Vet24.» El bloque de servicios es lo que evita que
+ * las 112 fichas compartan una plantilla intercambiable.
+ */
+export function buildClinicMetaDescription(data: ClinicMetaInput): string {
+  const copy = normalize(data.copyDiferenciador ?? "");
+  const core = pickServices(CORE_SERVICES, copy, data);
+  const diff = pickServices(DIFFERENTIATOR_SERVICES, copy, data);
+
+  // Un hotel específico (gatos) desplaza al genérico: no repetir el mismo dato.
+  if (diff[0] === "hotel exclusivo para gatos") {
+    const generic = diff.indexOf("hotel para mascotas");
+    if (generic > -1) diff.splice(generic, 1);
+  }
+
+  const selected = [...core.slice(0, 3), ...diff.slice(0, Math.max(1, 4 - Math.min(core.length, 3)))].slice(0, 4);
+
+  const location = buildLocation(data.zona, data.provincia);
+  const head = `${data.nombre} en ${location}.`;
+  const services = selected.length > 0 ? ` ${capitalize(joinEs(selected))}.` : "";
+  const tail = selected.length > 0
+    ? " Consulta dirección y contacto en Vet24."
+    : " Consulta dirección, teléfonos y datos de contacto en Vet24.";
+
+  let description = `${head}${services}${tail}`;
+
+  // Recorta servicios hasta caber en el largo útil de un snippet.
+  for (let count = selected.length; description.length > MAX_LENGTH && count > 0; count--) {
+    const trimmed = selected.slice(0, count - 1);
+    description = `${head}${trimmed.length ? ` ${capitalize(joinEs(trimmed))}.` : ""}${
+      trimmed.length ? " Consulta dirección y contacto en Vet24." : " Consulta dirección, teléfonos y datos de contacto en Vet24."
+    }`;
+  }
+
+  // Red de seguridad: si un dato de la ficha introdujera copy volátil (por
+  // ejemplo un nombre comercial con horario), se cae a la versión mínima en
+  // lugar de publicar una promesa que puede quedar obsoleta.
+  if (findVolatileMetadata(services).length > 0) {
+    description = `${head} Consulta dirección, teléfonos y datos de contacto en Vet24.`;
+  }
+
+  return description;
+}

--- a/src/lib/metaDescription.ts
+++ b/src/lib/metaDescription.ts
@@ -125,13 +125,11 @@ export function buildLocation(zona: string, provincia: string): string {
 const MAX_LENGTH = 165;
 
 /**
- * Construye la meta description de una ficha con datos estables.
- *
- * Formato: «{nombre} en {zona}, {provincia}. {servicios}. Consulta dirección,
- * teléfonos y servicios en Vet24.» El bloque de servicios es lo que evita que
- * las 112 fichas compartan una plantilla intercambiable.
+ * Selecciona los servicios estables que describen a la clínica (máx. 4):
+ * hasta 3 clínicos más al menos un rasgo diferenciador, para que las 112
+ * fichas no compartan una plantilla intercambiable.
  */
-export function buildClinicMetaDescription(data: ClinicMetaInput): string {
+function selectServices(data: ClinicMetaInput): string[] {
   const copy = normalize(data.copyDiferenciador ?? "");
   const core = pickServices(CORE_SERVICES, copy, data);
   const diff = pickServices(DIFFERENTIATOR_SERVICES, copy, data);
@@ -142,31 +140,56 @@ export function buildClinicMetaDescription(data: ClinicMetaInput): string {
     if (generic > -1) diff.splice(generic, 1);
   }
 
-  const selected = [...core.slice(0, 3), ...diff.slice(0, Math.max(1, 4 - Math.min(core.length, 3)))].slice(0, 4);
+  return [...core.slice(0, 3), ...diff.slice(0, Math.max(1, 4 - Math.min(core.length, 3)))].slice(0, 4);
+}
 
-  const location = buildLocation(data.zona, data.provincia);
-  const head = `${data.nombre} en ${location}.`;
-  const services = selected.length > 0 ? ` ${capitalize(joinEs(selected))}.` : "";
-  const tail = selected.length > 0
-    ? " Consulta dirección y contacto en Vet24."
-    : " Consulta dirección, teléfonos y datos de contacto en Vet24.";
+const CTA_WITH_SERVICES = " Consulta dirección y contacto en Vet24.";
+const CTA_WITHOUT_SERVICES = " Consulta dirección, teléfonos y datos de contacto en Vet24.";
 
-  let description = `${head}${services}${tail}`;
+/**
+ * Construye la meta description de una ficha con datos estables.
+ *
+ * Formato: «{nombre} en {zona}, {provincia}. {servicios}. Consulta dirección
+ * y contacto en Vet24.»
+ */
+export function buildClinicMetaDescription(data: ClinicMetaInput): string {
+  const selected = selectServices(data);
+  const head = `${data.nombre} en ${buildLocation(data.zona, data.provincia)}.`;
+
+  const compose = (services: string[]) =>
+    `${head}${services.length ? ` ${capitalize(joinEs(services))}.` : ""}${
+      services.length ? CTA_WITH_SERVICES : CTA_WITHOUT_SERVICES
+    }`;
+
+  let list = selected;
+  let description = compose(list);
 
   // Recorta servicios hasta caber en el largo útil de un snippet.
-  for (let count = selected.length; description.length > MAX_LENGTH && count > 0; count--) {
-    const trimmed = selected.slice(0, count - 1);
-    description = `${head}${trimmed.length ? ` ${capitalize(joinEs(trimmed))}.` : ""}${
-      trimmed.length ? " Consulta dirección y contacto en Vet24." : " Consulta dirección, teléfonos y datos de contacto en Vet24."
-    }`;
+  while (description.length > MAX_LENGTH && list.length > 0) {
+    list = list.slice(0, -1);
+    description = compose(list);
   }
 
   // Red de seguridad: si un dato de la ficha introdujera copy volátil (por
   // ejemplo un nombre comercial con horario), se cae a la versión mínima en
   // lugar de publicar una promesa que puede quedar obsoleta.
-  if (findVolatileMetadata(services).length > 0) {
-    description = `${head} Consulta dirección, teléfonos y datos de contacto en Vet24.`;
+  if (findVolatileMetadata(description.slice(head.length)).length > 0) {
+    description = `${head}${CTA_WITHOUT_SERVICES}`;
   }
 
   return description;
+}
+
+/**
+ * Descripción de la entidad para el JSON-LD `LocalBusiness` / `VeterinaryCare`.
+ *
+ * Misma base estable que la meta description, pero sin el CTA de Vet24: aquí se
+ * describe a la clínica, no se invita a navegar el directorio.
+ */
+export function buildClinicEntityDescription(data: ClinicMetaInput): string {
+  const selected = selectServices(data);
+  const head = `${data.nombre} en ${buildLocation(data.zona, data.provincia)}.`;
+  const services = selected.length > 0 ? ` ${capitalize(joinEs(selected))}.` : "";
+
+  return findVolatileMetadata(services).length > 0 ? head : `${head}${services}`;
 }

--- a/src/pages/clinica/[slug].astro
+++ b/src/pages/clinica/[slug].astro
@@ -5,6 +5,7 @@ import BadgeHorario from '../../components/BadgeHorario.astro';
 import linkzipCache from '../../linkzip-cache.json';
 import { absoluteUrl, canonicalUrl } from '../../lib/seo';
 import { getClinicZoneSlug } from '../../lib/zones';
+import { buildClinicMetaDescription } from '../../lib/metaDescription';
 import AdBanner from '../../components/AdBanner.astro';
 import {
   overnightDoctorStatus,
@@ -299,13 +300,24 @@ const clinicCanonical = canonicalUrl(`/clinica/${clinica.data.slug}/`);
 const provinceCanonical = absoluteUrl(`/provincia/${getProvinceSlug(provincia)}/`);
 const zoneCanonical = absoluteUrl(`/zona/${getClinicZoneSlug(zona)}/`);
 
+const pageTitle = nombre;
+
+// Hotfix SEO: la metadata NO puede depender del estado operativo (horario,
+// abierto/cerrado, 24/7, promesas de atención inmediata). Ese copy sobrevive
+// en cachés e índices después de que la ficha se corrige. Ver
+// src/lib/metaDescription.ts. El horario sigue visible en la página y en
+// `openingHoursSpecification` del JSON-LD.
+const pageDesc = buildClinicMetaDescription(clinica.data);
+
 // JSON-LD Schema Markup (Highly optimized for Local SEO)
 const schemaMarkup = {
   "@context": "https://schema.org",
   "@type": ["LocalBusiness", "VeterinaryCare"],
   "@id": clinicCanonical,
   "name": nombre,
-  "description": copyDiferenciador,
+  // Misma regla que la meta description: el JSON-LD también alimenta snippets,
+  // así que su `description` usa datos estables, no copy operativo.
+  "description": pageDesc,
   "image": schemaImage,
   "url": clinicCanonical,
   "telephone": telefono1 || whatsapp || "",
@@ -357,12 +369,6 @@ const schemaBreadcrumbs = {
   ]
 };
 
-const pageTitle = nombre;
-
-// Generate highly optimized meta description based on clinic emergency tier
-const pageDesc = emergencias24h
-  ? `¿Urgencia veterinaria? Contacta a ${nombre} en ${zona}, ${provincia}. Servicio de emergencias veterinarias 24/7. 📞 Llama ahora al ${telefono1 || whatsapp}. Atendemos de inmediato.`
-  : `Horarios, teléfono y dirección de ${nombre} en ${zona}, ${provincia}. Encuentra servicios veterinarios y de consulta general para tu mascota en Costa Rica.`;
 
 const schemaFaq = {
   "@context": "https://schema.org",

--- a/src/pages/clinica/[slug].astro
+++ b/src/pages/clinica/[slug].astro
@@ -5,7 +5,7 @@ import BadgeHorario from '../../components/BadgeHorario.astro';
 import linkzipCache from '../../linkzip-cache.json';
 import { absoluteUrl, canonicalUrl } from '../../lib/seo';
 import { getClinicZoneSlug } from '../../lib/zones';
-import { buildClinicMetaDescription } from '../../lib/metaDescription';
+import { buildClinicMetaDescription, buildClinicEntityDescription } from '../../lib/metaDescription';
 import AdBanner from '../../components/AdBanner.astro';
 import {
   overnightDoctorStatus,
@@ -308,6 +308,7 @@ const pageTitle = nombre;
 // src/lib/metaDescription.ts. El horario sigue visible en la página y en
 // `openingHoursSpecification` del JSON-LD.
 const pageDesc = buildClinicMetaDescription(clinica.data);
+const entityDesc = buildClinicEntityDescription(clinica.data);
 
 // JSON-LD Schema Markup (Highly optimized for Local SEO)
 const schemaMarkup = {
@@ -316,8 +317,9 @@ const schemaMarkup = {
   "@id": clinicCanonical,
   "name": nombre,
   // Misma regla que la meta description: el JSON-LD también alimenta snippets,
-  // así que su `description` usa datos estables, no copy operativo.
-  "description": pageDesc,
+  // así que su `description` usa datos estables, no copy operativo. Sin el CTA
+  // de Vet24, porque aquí se describe la entidad, no la página del directorio.
+  "description": entityDesc,
   "image": schemaImage,
   "url": clinicCanonical,
   "telephone": telefono1 || whatsapp || "",
@@ -376,10 +378,14 @@ const schemaFaq = {
   "mainEntity": [
     {
       "@type": "Question",
-      "name": `¿Cuál es el horario de ${nombre}?`,
+      "name": `¿Cómo confirmo el horario de ${nombre}?`,
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": `${nombre} reporta este horario: ${horarioTexto}. Recomendamos confirmar por teléfono o WhatsApp antes de trasladarte.`
+        // El horario NO se repite aquí: la FAQ estructurada es otra fuente desde
+        // la que un buscador puede reconstruir un snippet viejo cuando la clínica
+        // cambia de horario. El dato sigue visible en la ficha y en
+        // `openingHoursSpecification`, que sí se actualizan con la página.
+        "text": `El horario vigente de ${nombre} está publicado en su ficha de Vet24. Recomendamos confirmarlo por teléfono o WhatsApp antes de trasladarte.`
       }
     },
       {

--- a/tests/unit/metaDescription.test.ts
+++ b/tests/unit/metaDescription.test.ts
@@ -1,0 +1,132 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  buildClinicMetaDescription,
+  findVolatileMetadata,
+  VOLATILE_METADATA_PATTERNS,
+} from '../../src/lib/metaDescription.ts';
+
+const CLINIC_DIR = 'src/content/clinicas';
+
+/** Lector mínimo de frontmatter: solo los campos escalares que usa la metadata. */
+function readClinic(file: string): Record<string, any> {
+  const raw = readFileSync(join(CLINIC_DIR, file), 'utf8').replace(/^﻿/, '');
+  const match = raw.match(/^---\r?\n?([\s\S]*?)\r?\n---/);
+  assert.ok(match, `Frontmatter no encontrado en ${file}`);
+  const data: Record<string, any> = {};
+  for (const line of match![1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
+    if (!kv) continue;
+    let value: any = kv[2].trim();
+    if (value === '' || value === '|' || value === '>') continue;
+    if (/^".*"$/.test(value)) value = value.slice(1, -1);
+    else if (value === 'true') value = true;
+    else if (value === 'false') value = false;
+    else if (/^-?\d+(\.\d+)?$/.test(value)) value = Number(value);
+    data[kv[1]] = value;
+  }
+  return data;
+}
+
+const clinicFiles = readdirSync(CLINIC_DIR).filter((f) => f.endsWith('.md') && !f.startsWith('_'));
+
+describe('buildClinicMetaDescription — sin datos operativos volátiles', () => {
+  test('el dataset completo genera metadata sin horarios ni disponibilidad', () => {
+    assert.ok(clinicFiles.length > 100, 'se esperaba el dataset completo de fichas');
+    for (const file of clinicFiles) {
+      const data = readClinic(file);
+      const desc = buildClinicMetaDescription(data as any);
+      const volatile = findVolatileMetadata(desc);
+      assert.deepEqual(volatile, [], `${file} generó metadata volátil (${volatile.join(', ')}): ${desc}`);
+    }
+  });
+
+  test('las descripciones no son una plantilla intercambiable entre fichas', () => {
+    const descriptions = clinicFiles.map((f) => buildClinicMetaDescription(readClinic(f) as any));
+    // Quitando el nombre y la ubicación, debe quedar variedad real de contenido.
+    const bodies = new Set(descriptions.map((d) => d.split('. ').slice(1).join('. ')));
+    assert.ok(bodies.size >= 10, `demasiadas descripciones idénticas: ${bodies.size} variantes`);
+    assert.equal(new Set(descriptions).size, descriptions.length, 'hay descripciones duplicadas exactas');
+  });
+
+  test('nunca se construye a partir de horarioTexto', () => {
+    const base = {
+      nombre: 'Clínica Ejemplo',
+      zona: 'Heredia centro',
+      provincia: 'Heredia',
+      copyDiferenciador: 'Cirugía y laboratorio.',
+      has_surgery: true,
+    };
+    const conHorario = buildClinicMetaDescription({
+      ...base,
+      // @ts-expect-error: se pasa a propósito para comprobar que se ignora.
+      horarioTexto: 'L-D 9am-9pm jornada continua',
+      categoriaHorario: 'Cierra después 21h',
+      emergencias24h: true,
+    });
+    assert.equal(conHorario, buildClinicMetaDescription(base as any));
+    assert.ok(!conHorario.includes('9am'));
+  });
+
+  test('copy operativo en copyDiferenciador no llega a la metadata', () => {
+    const desc = buildClinicMetaDescription({
+      nombre: 'Hospital Ejemplo',
+      zona: 'Alajuela centro',
+      provincia: 'Alajuela',
+      copyDiferenciador:
+        'Horario continuo hasta las 9pm todos los días. Abierto 24/7, atendemos de inmediato. Cirugía e internamiento.',
+      has_surgery: true,
+      has_hospitalization: true,
+    });
+    assert.deepEqual(findVolatileMetadata(desc), []);
+  });
+
+  test('la ausencia de datos no se convierte en afirmación negativa', () => {
+    const desc = buildClinicMetaDescription({
+      nombre: 'Veterinaria Sin Datos',
+      zona: 'Nicoya',
+      provincia: 'Guanacaste',
+      copyDiferenciador: '',
+      has_surgery: false,
+      atiendeExoticos: false,
+    });
+    assert.ok(!/\bno\b/i.test(desc), `no debe negar servicios: ${desc}`);
+    assert.ok(desc.includes('Veterinaria Sin Datos'));
+  });
+
+  test('findVolatileMetadata detecta el copy prohibido', () => {
+    for (const sample of [
+      'L-D 9am-9pm jornada continua',
+      'Horario continuo hasta las 9pm',
+      'Abierto ahora',
+      'Emergencias 24/7',
+      'Atendemos 24 horas',
+      'Atendemos de inmediato',
+      'Atención nocturna de guardia',
+    ]) {
+      assert.notDeepEqual(findVolatileMetadata(sample), [], `no detectado: ${sample}`);
+    }
+    assert.ok(VOLATILE_METADATA_PATTERNS.length > 0);
+  });
+});
+
+describe('regresión — Hospital Veterinario Medical Care', () => {
+  const data = readClinic('hospital-vet-medical-care-heredia.md');
+  const desc = buildClinicMetaDescription(data as any);
+
+  test('no contiene el snippet viejo ni disponibilidad operativa', () => {
+    for (const forbidden of ['9am', '9pm', '9 a.m.', '9 p.m.', '24/7', 'Abierto ahora', 'Atendemos de inmediato']) {
+      assert.ok(!desc.toLowerCase().includes(forbidden.toLowerCase()), `metadata contiene "${forbidden}": ${desc}`);
+    }
+    assert.deepEqual(findVolatileMetadata(desc), []);
+  });
+
+  test('sigue siendo específica de Medical Care', () => {
+    assert.ok(desc.includes('Hospital Veterinario Medical Care'));
+    assert.ok(desc.includes('Heredia centro'));
+    assert.ok(/cirugía|internamiento|laboratorio|gatos/i.test(desc), desc);
+  });
+});

--- a/tests/unit/metaDescription.test.ts
+++ b/tests/unit/metaDescription.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 
 import {
   buildClinicMetaDescription,
+  buildClinicEntityDescription,
   findVolatileMetadata,
   VOLATILE_METADATA_PATTERNS,
 } from '../../src/lib/metaDescription.ts';
@@ -128,5 +129,45 @@ describe('regresión — Hospital Veterinario Medical Care', () => {
     assert.ok(desc.includes('Hospital Veterinario Medical Care'));
     assert.ok(desc.includes('Heredia centro'));
     assert.ok(/cirugía|internamiento|laboratorio|gatos/i.test(desc), desc);
+  });
+});
+
+describe('buildClinicEntityDescription — JSON-LD de la entidad', () => {
+  test('describe la clínica sin el CTA de Vet24 y sin datos volátiles', () => {
+    for (const file of clinicFiles) {
+      const data = readClinic(file) as any;
+      const entity = buildClinicEntityDescription(data);
+      assert.ok(!/Vet24/.test(entity), `${file} incluye CTA del directorio: ${entity}`);
+      assert.deepEqual(findVolatileMetadata(entity), [], `${file}: ${entity}`);
+      assert.ok(entity.startsWith(data.nombre), entity);
+    }
+  });
+
+  test('Medical Care queda descrito por sus servicios estables', () => {
+    const entity = buildClinicEntityDescription(readClinic('hospital-vet-medical-care-heredia.md') as any);
+    assert.equal(
+      entity,
+      'Hospital Veterinario Medical Care en Heredia centro. Cirugía, internamiento, laboratorio y hotel exclusivo para gatos.'
+    );
+  });
+});
+
+describe('structured data de la ficha', () => {
+  const page = readFileSync('src/pages/clinica/[slug].astro', 'utf8');
+  const faqBlock = page.slice(page.indexOf('const schemaFaq'), page.indexOf('---', page.indexOf('const schemaFaq')));
+
+  test('la FAQ estructurada no repite el horario declarado', () => {
+    assert.ok(!faqBlock.includes('${horarioTexto}'), 'schemaFaq no debe interpolar horarioTexto');
+    // El horario declarado (horas, rangos, jornada continua) no puede quedar
+    // congelado en la FAQ. Las respuestas sobre capacidad 24/7 sí se mantienen:
+    // son el dato factual de la ficha, no copy de horario.
+    for (const { name, pattern } of VOLATILE_METADATA_PATTERNS) {
+      if (['disponibilidad 24/7', '24 horas', 'guardia / nocturno', 'horario', 'estado de apertura'].includes(name)) continue;
+      assert.ok(!pattern.test(faqBlock), `schemaFaq contiene copy volátil (${name})`);
+    }
+  });
+
+  test('openingHoursSpecification sigue presente como dato factual', () => {
+    assert.ok(page.includes('"openingHoursSpecification": getOpeningHoursSpec()'));
   });
 });


### PR DESCRIPTION
## Problema

La ficha de Hospital Veterinario Medical Care se corrigió en #6, pero dos días después Google seguía sirviendo un snippet viejo con `L-D 9am-9pm jornada continua` y `Horario continuo hasta las 9pm todos los días`, y AI Overview respondía con ese horario obsoleto.

**El snippet viejo no venía de `<meta name="description">`.** Antes de #6 la ficha tenía `emergencias24h: false`, así que su meta description era la rama genérica *"Horarios, teléfono y dirección de…"*, sin horas. La combinación indexada se compuso de contenido visible + structured data:

- `horarioTexto` antiguo, renderizado en la ficha y además interpolado literalmente en la FAQ del JSON-LD;
- el badge visible de `atiendeExoticos` ("Exóticos");
- el `copyDiferenciador` antiguo, que alimentaba `"description"` del JSON-LD `LocalBusiness`.

El problema es general, no de una ficha: metadata y structured data estaban construidos con estado operativo. Cuando cambia un horario, la página se corrige el mismo día pero buscadores, cachés y sistemas de IA pueden seguir publicando la versión vieja durante días — una afirmación falsa sobre disponibilidad médica.

## Cambios

**`src/lib/metaDescription.ts` (nuevo)** — genera descripciones solo con atributos relativamente estables: nombre, zona, provincia y servicios registrados. Los servicios salen de los booleanos de la ficha (`has_surgery`, `has_hospitalization`, `atiendeExoticos`, `atiendeGranja`, `atiendePeces`, `hotelMascotas` + `hotelVerificacion`) y de una lista blanca de términos en `copyDiferenciador`. Se combinan hasta 3 servicios clínicos con al menos un rasgo diferenciador para que las 112 fichas no compartan una plantilla intercambiable. Nunca se inventa un servicio, y la ausencia de dato jamás se convierte en afirmación negativa (se respeta la regla semántica del hotfix anterior). Un guardián final descarta el bloque de servicios si detectara horas, rangos, `24/7`, estado de apertura o promesas de atención inmediata.

Dos salidas:
- `buildClinicMetaDescription()` → meta / og / twitter, con cierre de directorio.
- `buildClinicEntityDescription()` → JSON-LD de la entidad, sin CTA de Vet24.

**`src/pages/clinica/[slug].astro`**
- `pageDesc` ya no depende de `emergencias24h`, `telefono1` ni de copy de urgencia.
- `schemaMarkup.description` deja de reusar `copyDiferenciador` (prosa con horarios en varias fichas) y usa la descripción de entidad.
- `schemaFaq` deja de interpolar `horarioTexto`: la respuesta remite a la ficha y a confirmar por teléfono o WhatsApp. Era la última fuente estructurada desde la que se podía reconstruir un snippet viejo.

## Lo que se conserva deliberadamente

- El horario sigue **visible en la ficha**, sin cambios.
- `openingHoursSpecification` **intacto**: es el lugar correcto del dato factual estructurado y se actualiza junto con la página.
- Las respuestas FAQ sobre emergencias 24/7 y hotel no cambian: son el dato factual de la ficha, no copy de horario.
- Sin cambios en la lógica de horarios, filtros ni "Abierto ahora".

## Resultado en Medical Care

```
meta / og / twitter:
Hospital Veterinario Medical Care en Heredia centro. Cirugía, internamiento,
laboratorio y hotel exclusivo para gatos. Consulta dirección y contacto en Vet24.

JSON-LD description:
Hospital Veterinario Medical Care en Heredia centro. Cirugía, internamiento,
laboratorio y hotel exclusivo para gatos.
```

Sin `9am-9pm`, `9 a.m.`, `9pm`, `24/7`, `Abierto ahora`, `Atendemos de inmediato` ni promesa de disponibilidad, y sigue siendo específica de esta clínica.

## Tests y build

`tests/unit/metaDescription.test.ts` prueba la regla global, no solo Medical Care:

- las **112 fichas reales** generan metadata y descripción de entidad sin ningún patrón volátil;
- las descripciones no son una plantilla intercambiable (≥10 cuerpos distintos, sin duplicados exactos);
- la descripción es independiente de `horarioTexto`, `categoriaHorario` y `emergencias24h`;
- copy operativo dentro de `copyDiferenciador` no llega a la metadata;
- la ausencia de datos no produce afirmaciones negativas;
- guardia de que `schemaFaq` no vuelva a interpolar `horarioTexto` y de que `openingHoursSpecification` siga presente;
- regresión explícita de Medical Care.

`npm run test:unit`: 35/35 pass. `astro build`: completo, 112 fichas; barrido sobre el HTML generado: 0 metadata y 0 respuestas FAQ con horas, rangos o "jornada continua".

Los e2e de Playwright no corren en el entorno de esta sesión (falta el binario `chrome-headless-shell`); es una limitación preexistente del entorno, ajena a este cambio.

## Riesgo residual

Google puede seguir generando su propio snippet desde el texto visible: el horario aparece en la ficha (bloque de horario, aviso "reporta este horario…", panel lateral). La metadata y el structured data ya no lo sugieren, pero conviene re-solicitar indexación (`npm run indexing`) para acelerar el refresco del snippet actual.

Fuera de alcance, sin tocar: `hotelMascotasNota` (#5), tooltips (#7), Tiers, rediseño de ficha, datos de horarios, filtros y limpieza general de SEO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzgDARENqPqH1hjPBbCM1e

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzgDARENqPqH1hjPBbCM1e)_