### PR TITLE
fix(datos): corregir horario de Veterinaria Gocha y soportar medias horas

### DIFF
--- a/src/components/ClinicaCard.astro
+++ b/src/components/ClinicaCard.astro
@@ -55,13 +55,14 @@ const normalizeHours = (text: string) => {
 };
 
 const hourTo24 = (value: string) => {
-  const match = value.match(/^(\d{1,2})(am|pm)$/);
+  const match = value.match(/^(\d{1,2})(?::(\d{2}))?(am|pm)$/);
   if (!match) return null;
   let hour = Number(match[1]);
-  const period = match[2];
+  const minutes = match[2] ? Number(match[2]) : 0;
+  const period = match[3];
   if (period === 'pm' && hour < 12) hour += 12;
   if (period === 'am' && hour === 12) hour = 0;
-  return hour;
+  return hour + minutes / 60;
 };
 
 const rangeToSchedule = (days: string, start: string, end: string) => {
@@ -87,12 +88,12 @@ if (clinica.emergencias24h) {
   } else {
     const rules: string[] = [];
     const dayPatterns = [
-      { pattern: /l-d(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "1-0" },
-      { pattern: /l-s(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "1-6" },
-      { pattern: /l-v(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "1-5" },
-      { pattern: /s-d(?:soloemergencias)?(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "6-0" },
-      { pattern: /d(?:yferiados)?(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "0" },
-      { pattern: /s(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "6" },
+      { pattern: /l-d(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "1-0" },
+      { pattern: /l-s(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "1-6" },
+      { pattern: /l-v(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "1-5" },
+      { pattern: /s-d(?:soloemergencias)?(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "6-0" },
+      { pattern: /d(?:yferiados)?(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "0" },
+      { pattern: /s(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "6" },
     ];
 
     for (const { pattern, days } of dayPatterns) {

--- a/src/components/FiltrosDashboard.astro
+++ b/src/components/FiltrosDashboard.astro
@@ -295,7 +295,9 @@
 
   // ─── Status update ─────────────────────────────────────────────────────
   function updateClinicsStatus() {
-    const { day, hour } = getCostaRicaTime();
+    const { day, hour: currentHour, minute } = getCostaRicaTime();
+    // Fractional hour so schedules with half hours (e.g. 8:30am-6:30pm) are exact
+    const hour = currentHour + minute / 60;
     const cards = document.querySelectorAll<HTMLElement>('#clinicas-grid article');
     let openCount = 0;
 

--- a/src/content/clinicas/veterinaria-gocha-santo-domingo.md
+++ b/src/content/clinicas/veterinaria-gocha-santo-domingo.md
@@ -6,8 +6,8 @@ direccion: "De la McDonald's de Santo Domingo, 50 m este y 50 m norte, Santo Dom
 telefono1: "4000-2795"
 telefono2: "2244-8726"
 whatsapp: "8964-6632"
-horarioTexto: "Urgencias 24/7 — canal exclusivo nocturno"
-categoriaHorario: "Cierra después 21h"
+horarioTexto: "L-S 8:30am-6:30pm · Dom cerrado — urgencias nocturnas por teléfono"
+categoriaHorario: "Horario normal"
 emergencias24h: false
 atiendeExoticos: true
 cirugiaEmergencia: false
@@ -22,7 +22,7 @@ copyDiferenciador: "14 años sirviendo a Santo Domingo. Canal telefónico exclus
 confidence_score: "medium"
 record_status: "PARTIAL"
 emergency_tier: "Tier B"
-last_verified: ""
+last_verified: "2026-09-05"
 phone_verified: true
 address_verified: true
 schedule_verified: true
@@ -30,8 +30,8 @@ emergency_verified: false
 has_surgery: false
 has_hospitalization: false
 overnight_doctor_present: false
-verification_notes: ["Canal telefónico exclusivo nocturno 24/7 confirmado (4000-2795). Atención física diurna L-S 8:30am-6:30pm. NO hay médico físico en sitio de madrugada. Tier B correcto."]
-verification_source: "Búsqueda web — micanton.com, wanderboat.ai"
+verification_notes: ["2026-09-05: Horario corregido con la ficha de Google Business (L-S 8:30am-6:30pm, domingo cerrado). Antes el horarioTexto sólo decía 'Urgencias 24/7' y el parser no extraía ninguna regla, por lo que la clínica aparecía 'Cerrado ahora' las 24 horas.", "Canal telefónico exclusivo nocturno 24/7 confirmado (4000-2795). NO hay médico físico en sitio de madrugada. Tier B correcto."]
+verification_source: "Google Business Profile (horario y teléfono 2244-8726), verificado 2026-09-05; previo: micanton.com, wanderboat.ai"
 latitude: 9.9759
 longitude: -84.0721
 waze_url: "https://waze.com/ul?q=Veterinaria%20Gocha%20Santo%20Domingo%20de%20Heredia%20Heredia%20Costa%20Rica&navigate=yes"

--- a/src/pages/clinica/[slug].astro
+++ b/src/pages/clinica/[slug].astro
@@ -119,13 +119,14 @@ const normalizeHours = (text: string) => {
 };
 
 const hourTo24 = (value: string) => {
-  const match = value.match(/^(\d{1,2})(am|pm)$/);
+  const match = value.match(/^(\d{1,2})(?::(\d{2}))?(am|pm)$/);
   if (!match) return null;
   let hour = Number(match[1]);
-  const period = match[2];
+  const minutes = match[2] ? Number(match[2]) : 0;
+  const period = match[3];
   if (period === 'pm' && hour < 12) hour += 12;
   if (period === 'am' && hour === 12) hour = 0;
-  return hour;
+  return hour + minutes / 60;
 };
 
 const rangeToSchedule = (days: string, start: string, end: string) => {
@@ -154,12 +155,12 @@ const getClientScheduleAttr = () => {
 
   const rules: string[] = [];
   const dayPatterns = [
-    { pattern: /l-d(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "1-0" },
-    { pattern: /l-s(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "1-6" },
-    { pattern: /l-v(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "1-5" },
-    { pattern: /s-d(?:soloemergencias)?(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "6-0" },
-    { pattern: /d(?:yferiados)?(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "0" },
-    { pattern: /s(\d{1,2}(?:am|pm))-(\d{1,2}(?:am|pm))/, days: "6" },
+    { pattern: /l-d(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "1-0" },
+    { pattern: /l-s(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "1-6" },
+    { pattern: /l-v(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "1-5" },
+    { pattern: /s-d(?:soloemergencias)?(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "6-0" },
+    { pattern: /d(?:yferiados)?(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "0" },
+    { pattern: /s(\d{1,2}(?::\d{2})?(?:am|pm))-(\d{1,2}(?::\d{2})?(?:am|pm))/, days: "6" },
   ];
 
   for (const { pattern, days } of dayPatterns) {


### PR DESCRIPTION
## Problema

Veterinaria Gocha aparecía como **"Cerrado ahora" las 24 horas, los 7 días**.

No era un dato mal copiado, era un fallo silencioso del parser de horarios: el estado abierto/cerrado se deduce con regex desde el string en español `horarioTexto`. Gocha tenía `horarioTexto: "Urgencias 24/7 — canal exclusivo nocturno"`, sin ningún rango horario extraíble, así que `data-schedule` salía vacío y el badge caía siempre en "Cerrado". El badge de categoría además decía "Cierra después 21h", también falso.

Impacto: la ficha se contradecía en pantalla y le indicaba a buscadores, LLMs y clientes que la clínica estaba cerrada.

## Cambios

**Datos** — `src/content/clinicas/veterinaria-gocha-santo-domingo.md`
- Horario real según su ficha de Google Business: L-S 8:30am-6:30pm, domingo cerrado.
- `categoriaHorario` pasa de `"Cierra después 21h"` a `"Horario normal"`.
- `last_verified`, `verification_source` y `verification_notes` actualizados con el detalle del incidente.
- `emergencias24h` se mantiene en `false`: el canal nocturno es telefónico, no hay médico físico en sitio de madrugada (Tier B sin cambios).

**Parser de horarios** — `src/components/ClinicaCard.astro`, `src/pages/clinica/[slug].astro`
- `hourTo24` sólo aceptaba horas en punto (`8am`); un `8:30am` no matcheaba nada y producía el mismo cero silencioso. Ahora acepta minutos y devuelve hora fraccionaria.

**Evaluación en cliente** — `src/components/FiltrosDashboard.astro`
- Comparaba sólo la hora entera, ignorando los minutos que ya calculaba. Ahora usa `hora + minutos / 60`.

## Verificación

- `astro build` en verde; la página renderizada emite `data-schedule="1-6:8.5-18.5,6:8.5-18.5"`.
- Casos probados contra la lógica de apertura: lun 8:15am → cerrado, 8:36am → abierto, 6:24pm → abierto, 6:36pm → cerrado, sáb 10am → abierto, dom → cerrado, lun 1:30am → cerrado.
- Auditadas las 112 fichas de contenido: ninguna otra ficha publicada queda sin regla de horario legible.

## Deuda que este PR no resuelve

- El fallo es silencioso por diseño: si el regex no matchea, el sitio no avisa, muestra "Cerrado". Debería romper el build.
- El horario debería ser un campo estructurado validado en `content.config.ts`, no prosa parseada.
- La lógica está duplicada en `ClinicaCard.astro` y `clinica/[slug].astro`, y `FiltrosDashboard.astro` es una tercera implementación con reglas propias.
- Hay casos hardcodeados por nombre de clínica dentro del parser.
- No hay tests de la función horaria.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bk3YpQemYzRdrz9UP6MuAk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk3YpQemYzRdrz9UP6MuAk)_