### PR TITLE
docs(ar1): archivar evidencia de verificación post-despliegue

### DIFF
--- a/docs/agent-readiness/evidencia/ar1/robots-post-deploy.json
+++ b/docs/agent-readiness/evidencia/ar1/robots-post-deploy.json
@@ -1,0 +1,14 @@
+{
+  "checkedAt": "2026-09-06T04:58:38.1413386Z",
+  "url": "https://vet24cr.com/robots.txt",
+  "status": 200,
+  "contentType": "Content-Type: text/plain",
+  "required": {
+    "Content-Signal in wildcard block": true,
+    "Content-Signal once": true,
+    "Sitemap": true,
+    "User-agent: *": true,
+    "Allow: /": true
+  },
+  "body": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+}

--- a/docs/agent-readiness/evidencia/ar1/scan-post-deploy.json
+++ b/docs/agent-readiness/evidencia/ar1/scan-post-deploy.json
@@ -1,0 +1,1290 @@
+{
+  "url": "https://vet24cr.com",
+  "targetUrl": "https://vet24cr.com",
+  "scannedAt": "2026-09-06T04:58:54.538Z",
+  "level": 2,
+  "levelName": "Bot-Aware",
+  "checks": {
+    "discoverability": {
+      "robotsTxt": {
+        "status": "pass",
+        "message": "robots.txt exists with valid format",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /robots.txt",
+            "request": {
+              "url": "https://vet24cr.com/robots.txt",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/plain",
+                "content-length": "125",
+                "cf-ray": "a36ae6964c0f7df0-SJO"
+              },
+              "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received valid robots.txt (200, text/plain)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Validate robots.txt structure",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Contains valid User-agent directive(s)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "robots.txt exists with valid format"
+            }
+          }
+        ],
+        "durationMs": 0
+      },
+      "sitemap": {
+        "status": "pass",
+        "message": "sitemap.xml exists with valid structure",
+        "details": {
+          "url": "https://vet24cr.com/sitemap-index.xml",
+          "fromRobotsTxt": true,
+          "format": "xml"
+        },
+        "evidence": [
+          {
+            "action": "parse",
+            "label": "Extract Sitemap directives from robots.txt",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found 1 Sitemap directive(s) in robots.txt"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /sitemap-index.xml",
+            "request": {
+              "url": "https://vet24cr.com/sitemap-index.xml",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/xml",
+                "content-length": "182",
+                "cf-ray": "a36ae6969c397df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found valid xml sitemap at https://vet24cr.com/sitemap-index.xml"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "sitemap.xml exists with valid structure"
+            }
+          }
+        ],
+        "durationMs": 8
+      },
+      "linkHeaders": {
+        "status": "fail",
+        "message": "No Link headers found on target page",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6970ca97df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "No Link header present in response"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No Link headers found on target page"
+            }
+          }
+        ],
+        "durationMs": 92
+      },
+      "dnsAid": {
+        "status": "fail",
+        "message": "DNS for AI Discovery (DNS-AID) well-known entrypoint records not found",
+        "details": {
+          "domainsChecked": [
+            "vet24cr.com"
+          ],
+          "queriesAttempted": [
+            "SVCB _index._agents.vet24cr.com",
+            "HTTPS _index._agents.vet24cr.com",
+            "SVCB _a2a._agents.vet24cr.com",
+            "HTTPS _a2a._agents.vet24cr.com",
+            "SVCB _mcp._agents.vet24cr.com",
+            "HTTPS _mcp._agents.vet24cr.com",
+            "TXT _index._agents.vet24cr.com"
+          ],
+          "dnssecValidated": false,
+          "serviceRecordCount": 0,
+          "aliasRecordCount": 0,
+          "txtIndexEntryCount": 0,
+          "txtIndexEntries": [],
+          "records": []
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "DoH SVCB _index._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_index._agents.vet24cr.com&type=SVCB&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SVCB answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH HTTPS _index._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_index._agents.vet24cr.com&type=HTTPS&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No HTTPS answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH SVCB _a2a._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_a2a._agents.vet24cr.com&type=SVCB&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SVCB answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH HTTPS _a2a._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_a2a._agents.vet24cr.com&type=HTTPS&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No HTTPS answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH SVCB _mcp._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_mcp._agents.vet24cr.com&type=SVCB&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SVCB answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH HTTPS _mcp._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_mcp._agents.vet24cr.com&type=HTTPS&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No HTTPS answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH TXT _index._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_index._agents.vet24cr.com&type=TXT&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No TXT answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Parse DNS for AI Discovery (DNS-AID) SVCB/HTTPS records",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No DNS for AI Discovery (DNS-AID) SVCB or HTTPS records found at well-known entrypoints"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "DNS for AI Discovery (DNS-AID) well-known entrypoint records not found"
+            }
+          }
+        ],
+        "durationMs": 14
+      }
+    },
+    "contentAccessibility": {
+      "markdownNegotiation": {
+        "status": "fail",
+        "message": "Site does not support Markdown for Agents",
+        "details": {
+          "contentType": "text/html"
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET target page (Accept: text/markdown)",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET",
+              "headers": {
+                "accept": "text/markdown",
+                "cache-control": "no-cache"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Response content-type is text/html, not text/markdown -- site does not support markdown content negotiation"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6a15cb7adfa-MIA"
+              }
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "Site does not support Markdown for Agents"
+            }
+          }
+        ],
+        "durationMs": 680
+      }
+    },
+    "botAccessControl": {
+      "robotsTxtAiRules": {
+        "status": "pass",
+        "message": "No AI-specific bot rules; wildcard rules apply to all crawlers including AI bots",
+        "details": {
+          "checkedBots": [
+            "gptbot",
+            "chatgpt-user",
+            "google-extended",
+            "ccbot",
+            "anthropic-ai",
+            "claude-web",
+            "bytespider",
+            "perplexitybot",
+            "cohere-ai",
+            "applebot-extended",
+            "amazonbot",
+            "meta-externalagent",
+            "facebookbot",
+            "omgilibot",
+            "diffbot"
+          ]
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /robots.txt",
+            "request": {
+              "url": "https://vet24cr.com/robots.txt",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/plain",
+                "content-length": "125",
+                "cf-ray": "a36ae6964c0f7df0-SJO"
+              },
+              "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received valid robots.txt (200, text/plain)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Scan for AI bot User-agent directives",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Checked 15 AI bot user agents -- none found, but wildcard rules apply"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "No AI-specific bot rules; wildcard rules apply to all crawlers including AI bots"
+            }
+          }
+        ],
+        "durationMs": 0
+      },
+      "contentSignals": {
+        "status": "pass",
+        "message": "Content Signals found in robots.txt",
+        "details": {
+          "signals": [
+            {
+              "userAgent": "*",
+              "path": null,
+              "aiTrain": "no",
+              "search": "yes",
+              "aiInput": "yes"
+            }
+          ],
+          "signalCount": 1
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /robots.txt",
+            "request": {
+              "url": "https://vet24cr.com/robots.txt",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/plain",
+                "content-length": "125",
+                "cf-ray": "a36ae6964c0f7df0-SJO"
+              },
+              "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received valid robots.txt (200, text/plain)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Parse Content-Signal directives",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found 1 Content-Signal directive(s)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Content Signals found in robots.txt"
+            }
+          }
+        ],
+        "durationMs": 0
+      },
+      "webBotAuth": {
+        "status": "neutral",
+        "message": "Web Bot Auth directory not found (informational only)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/http-message-signatures-directory",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/http-message-signatures-directory",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6969c387df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- Web Bot Auth directory not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "Web Bot Auth directory not found"
+            }
+          }
+        ],
+        "durationMs": 7
+      }
+    },
+    "discovery": {
+      "apiCatalog": {
+        "status": "fail",
+        "message": "API Catalog not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/api-catalog",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/api-catalog",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/linkset+json, application/json"
+              }
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696cc5b7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- API Catalog not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "API Catalog not found"
+            }
+          }
+        ],
+        "durationMs": 37
+      },
+      "oauthDiscovery": {
+        "status": "fail",
+        "message": "No OAuth/OIDC discovery metadata found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/openid-configuration",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/openid-configuration",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6969c3a7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "openid-configuration returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/oauth-authorization-server",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/oauth-authorization-server",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6969c3c7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "oauth-authorization-server returned 404"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No OAuth/OIDC discovery metadata found at either well-known path"
+            }
+          }
+        ],
+        "durationMs": 9
+      },
+      "oauthProtectedResource": {
+        "status": "fail",
+        "message": "No OAuth Protected Resource Metadata found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/oauth-protected-resource",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/oauth-protected-resource",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6969c3d7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696ac407df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Target resource returned 200 (no WWW-Authenticate header)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No OAuth Protected Resource Metadata found"
+            }
+          }
+        ],
+        "durationMs": 27
+      },
+      "authMd": {
+        "status": "fail",
+        "message": "auth.md not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /auth.md",
+            "request": {
+              "url": "https://vet24cr.com/auth.md",
+              "method": "GET",
+              "headers": {
+                "Accept": "text/markdown, text/plain, */*"
+              }
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696ac437df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 - auth.md not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "auth.md not found"
+            }
+          }
+        ],
+        "durationMs": 30
+      },
+      "mcpServerCard": {
+        "status": "fail",
+        "message": "MCP Server Card not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/mcp/server-card.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/mcp/server-card.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696ac457df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "/.well-known/mcp/server-card.json returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/mcp/server-cards.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/mcp/server-cards.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696ac487df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "/.well-known/mcp/server-cards.json returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/mcp.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/mcp.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696ac4a7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "/.well-known/mcp.json returned 404"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "MCP Server Card not found at any candidate path"
+            }
+          }
+        ],
+        "durationMs": 30
+      },
+      "a2aAgentCard": {
+        "status": "fail",
+        "message": "A2A Agent Card not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/agent-card.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/agent-card.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696ac4b7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- A2A Agent Card not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "A2A Agent Card not found"
+            }
+          }
+        ],
+        "durationMs": 31
+      },
+      "agentSkills": {
+        "status": "fail",
+        "message": "Agent Skills index not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/agent-skills/index.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/agent-skills/index.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696cc597df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "v0.2.0 path returned 404 — trying legacy path"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/skills/index.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/skills/index.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6970cac7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 — Agent Skills index not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "Agent Skills index not found"
+            }
+          }
+        ],
+        "durationMs": 95
+      },
+      "webMcp": {
+        "status": "fail",
+        "message": "No WebMCP tools detected on page load",
+        "evidence": [
+          {
+            "action": "parse",
+            "label": "WebMCP detection",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Checking page for WebMCP tool registrations"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "Navigate to https://vet24cr.com",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Loading page to detect WebMCP tool registrations"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Check imperative WebMCP API",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No tools registered via navigator.modelContext"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No WebMCP tools detected on page load"
+            }
+          }
+        ],
+        "durationMs": 4325
+      },
+      "ard": {
+        "status": "fail",
+        "message": "ARD capability manifest not found",
+        "evidence": [
+          {
+            "action": "parse",
+            "label": "Extract Agentmap directives from robots.txt",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No Agentmap directives found"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Extract <link rel=\"ai-catalog\"> from page head",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No catalog links found"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/ai-catalog.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/ai-catalog.json",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/json"
+              }
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6969c367df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- ai-catalog.json not found"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH TXT _catalog._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_catalog._agents.vet24cr.com&type=TXT&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_catalog._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No TXT answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH SRV _search._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_search._agents.vet24cr.com&type=SRV&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_search._agents.vet24cr.com\",\"type\":33}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SRV answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "ARD capability manifest not found"
+            }
+          }
+        ],
+        "details": {
+          "discoveryMechanisms": [],
+          "searchEndpoints": []
+        },
+        "durationMs": 8
+      }
+    },
+    "commerce": {
+      "x402": {
+        "status": "neutral",
+        "message": "x402 payment protocol not detected (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /",
+            "request": {
+              "url": "https://vet24cr.com/",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696cc607df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/ returned 200 (not 402)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /api",
+            "request": {
+              "url": "https://vet24cr.com/api",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6970cb07df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/api returned 404 (not 402)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /api/v1",
+            "request": {
+              "url": "https://vet24cr.com/api/v1",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae6970cb17df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/api/v1 returned 404 (not 402)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /platform/v2/x402/discovery/resources",
+            "request": {
+              "url": "https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources?limit=500",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/json",
+                "cf-ray": "a36ae696cc5e7df0-SJO"
+              }
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET Bazaar discovery API",
+            "request": {
+              "url": "https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources?limit=500",
+              "method": "GET"
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Network error querying Bazaar API"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "x402 payment protocol not detected"
+            }
+          }
+        ],
+        "durationMs": 1348
+      },
+      "mpp": {
+        "status": "neutral",
+        "message": "MPP payment discovery not detected (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /openapi.json",
+            "request": {
+              "url": "https://vet24cr.com/openapi.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696dc6d7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/openapi.json returned 404"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "MPP payment discovery not detected"
+            }
+          }
+        ],
+        "durationMs": 70
+      },
+      "ucp": {
+        "status": "neutral",
+        "message": "UCP profile not found (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/ucp",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/ucp",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696cc5d7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- UCP profile not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "UCP profile not found"
+            }
+          }
+        ],
+        "durationMs": 37
+      },
+      "acp": {
+        "status": "neutral",
+        "message": "ACP discovery document not found (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/acp.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/acp.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ae696dc707df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- ACP discovery document not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "ACP discovery document not found"
+            }
+          }
+        ],
+        "durationMs": 70
+      },
+      "ap2": {
+        "status": "neutral",
+        "message": "AP2 not detected (no A2A Agent Card) (not a commerce site)",
+        "evidence": [
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No A2A Agent Card found -- AP2 requires an A2A Agent Card"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "nextLevel": {
+    "target": 3,
+    "name": "Agent-Readable",
+    "requirements": [
+      {
+        "check": "markdownNegotiation",
+        "description": "Support Accept: text/markdown content negotiation for machine-readable content",
+        "shortPrompt": "Enable Markdown for Agents so requests with Accept: text/markdown return a markdown version of your HTML.",
+        "specUrls": [
+          "https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/"
+        ],
+        "prompt": "Implement content negotiation so requests with Accept: text/markdown return a markdown representation while HTML remains the default for browsers.",
+        "skillUrl": "https://isitagentready.com/.well-known/agent-skills/markdown-negotiation/SKILL.md"
+      }
+    ]
+  },
+  "isCommerce": false,
+  "commerceSignals": [
+    "url:/cart"
+  ]
+}


### PR DESCRIPTION
Cierra el ciclo de verificación de AR1 (issue #12), reabierto tras el cierre automático prematuro que causó `Closes #12` en el PR #17.

## Summary
- `docs/agent-readiness/evidencia/ar1/robots-post-deploy.json`: `curl` de producción (`checkedAt: 2026-09-06T04:58:38Z`) confirmando **AR1-01** — 200, `Content-Signal: search=yes, ai-input=yes, ai-train=no` una sola vez dentro del bloque comodín, `Allow:`/`Sitemap:` intactos.
- `docs/agent-readiness/evidencia/ar1/scan-post-deploy.json`: escaneo completo post-despliegue (`scannedAt: 2026-09-06T04:58:54Z`) confirmando **AR1-02** — `robotsTxt=pass`, `sitemap=pass`, `robotsTxtAiRules=pass`, `contentSignals=pass`. El sitio pasa de nivel 1 (Basic Web Presence) a nivel 2 (Bot-Aware).

## Alcance
Solo documentación/evidencia — dos archivos nuevos, sin tocar código de producto.

## Verificación de esta sesión
- Comparé `scan-pre-deploy.json` (03:20:57Z, `contentSignals=fail`) contra `scan-post-deploy.json` (04:58:54Z, `contentSignals=pass`): línea base y resultado consistentes, fechas coherentes con el despliegue.
- `robots-post-deploy.json` coincide byte a byte con el `public/robots.txt` fusionado en `main` (commit `65bf7e2`).
- `git diff --stat` contra `main`: limitado a los dos archivos de evidencia.

Con esto, AR1-01, AR1-02 y AR1-03 quedan verificados. Corresponde cerrar el issue #12 al fusionar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1yPvd9UaNksNZXqRdTosZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1yPvd9UaNksNZXqRdTosZ)_