### PR TITLE
feat(ar2): publish agent catalog and discovery resources

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,9 @@ export default defineConfig({
   trailingSlash: 'always',
   output: 'static',
   adapter: cloudflare(),
-  integrations: [sitemap()],
+  integrations: [sitemap({
+    filter: (page) => !/[\\/]?(api|auth\.md|llms\.txt|\.well-known)([/.]|$)/.test(new URL(page).pathname),
+  })],
   server: {
     // Respect the PORT env var (e.g. from tooling) but keep 4321 as default
     port: process.env.PORT ? Number(process.env.PORT) : 4321

--- a/docs/agent-readiness/evidencia/ar2/base.json
+++ b/docs/agent-readiness/evidencia/ar2/base.json
@@ -1,0 +1,7 @@
+{
+  "phase": "AR2",
+  "baseSha": "06cab06db0e3ffca2f5b314276af5dda4b831db7",
+  "branch": "ar2/catalog-discovery",
+  "preDeployScan": "scan-pre-deploy.json",
+  "note": "La línea base se tomó contra producción aún en AR1 antes del despliegue de AR2; por una omisión de coordinación se archivó después de iniciar la implementación local, pero antes de cualquier despliegue de esta rama. No se presenta como verificación post-despliegue."
+}

--- a/docs/agent-readiness/evidencia/ar2/scan-pre-deploy.json
+++ b/docs/agent-readiness/evidencia/ar2/scan-pre-deploy.json
@@ -1,7 +1,7 @@
 {
   "url": "https://vet24cr.com",
   "targetUrl": "https://vet24cr.com",
-  "scannedAt": "2026-09-06T05:35:13.490Z",
+  "scannedAt": "2026-09-06T07:00:32.470Z",
   "level": 2,
   "levelName": "Bot-Aware",
   "checks": {
@@ -23,7 +23,7 @@
               "headers": {
                 "content-type": "text/plain",
                 "content-length": "125",
-                "cf-ray": "a36b1bc85cae7df0-SJO"
+                "cf-ray": "a36b98c38cde7df0-SJO"
               },
               "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
             },
@@ -81,7 +81,7 @@
               "headers": {
                 "content-type": "application/xml",
                 "content-length": "182",
-                "cf-ray": "a36b1bc88cba7df0-SJO"
+                "cf-ray": "a36b98c3dcea7df0-SJO"
               }
             },
             "finding": {
@@ -116,7 +116,7 @@
               "statusText": "OK",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8eced7df0-SJO"
+                "cf-ray": "a36b98c43d117df0-SJO"
               }
             },
             "finding": {
@@ -133,7 +133,7 @@
             }
           }
         ],
-        "durationMs": 76
+        "durationMs": 86
       },
       "dnsAid": {
         "status": "fail",
@@ -175,7 +175,7 @@
               "headers": {
                 "content-type": "application/dns-json"
               },
-              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
             },
             "finding": {
               "outcome": "neutral",
@@ -198,7 +198,7 @@
               "headers": {
                 "content-type": "application/dns-json"
               },
-              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
             },
             "finding": {
               "outcome": "neutral",
@@ -221,7 +221,7 @@
               "headers": {
                 "content-type": "application/dns-json"
               },
-              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
             },
             "finding": {
               "outcome": "neutral",
@@ -244,7 +244,7 @@
               "headers": {
                 "content-type": "application/dns-json"
               },
-              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
             },
             "finding": {
               "outcome": "neutral",
@@ -267,7 +267,7 @@
               "headers": {
                 "content-type": "application/dns-json"
               },
-              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
             },
             "finding": {
               "outcome": "neutral",
@@ -290,7 +290,7 @@
               "headers": {
                 "content-type": "application/dns-json"
               },
-              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
             },
             "finding": {
               "outcome": "neutral",
@@ -313,7 +313,7 @@
               "headers": {
                 "content-type": "application/dns-json"
               },
-              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
             },
             "finding": {
               "outcome": "neutral",
@@ -337,7 +337,7 @@
             }
           }
         ],
-        "durationMs": 2
+        "durationMs": 5
       }
     },
     "contentAccessibility": {
@@ -368,7 +368,7 @@
               "statusText": "OK",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bd53db4bd73-MIA"
+                "cf-ray": "a36b98cf180ba587-MIA"
               }
             }
           },
@@ -381,7 +381,7 @@
             }
           }
         ],
-        "durationMs": 593
+        "durationMs": 766
       }
     },
     "botAccessControl": {
@@ -421,7 +421,7 @@
               "headers": {
                 "content-type": "text/plain",
                 "content-length": "125",
-                "cf-ray": "a36b1bc85cae7df0-SJO"
+                "cf-ray": "a36b98c38cde7df0-SJO"
               },
               "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
             },
@@ -478,7 +478,7 @@
               "headers": {
                 "content-type": "text/plain",
                 "content-length": "125",
-                "cf-ray": "a36b1bc85cae7df0-SJO"
+                "cf-ray": "a36b98c38cde7df0-SJO"
               },
               "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
             },
@@ -522,7 +522,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc88cbc7df0-SJO"
+                "cf-ray": "a36b98c3dce97df0-SJO"
               }
             },
             "finding": {
@@ -539,7 +539,7 @@
             }
           }
         ],
-        "durationMs": 6
+        "durationMs": 8
       }
     },
     "discovery": {
@@ -562,7 +562,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8bcdb7df0-SJO"
+                "cf-ray": "a36b98c40cfd7df0-SJO"
               }
             },
             "finding": {
@@ -579,7 +579,7 @@
             }
           }
         ],
-        "durationMs": 41
+        "durationMs": 34
       },
       "oauthDiscovery": {
         "status": "fail",
@@ -597,7 +597,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc88cbb7df0-SJO"
+                "cf-ray": "a36b98c3dce57df0-SJO"
               }
             },
             "finding": {
@@ -617,7 +617,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc88cbd7df0-SJO"
+                "cf-ray": "a36b98c3dcec7df0-SJO"
               }
             },
             "finding": {
@@ -634,7 +634,7 @@
             }
           }
         ],
-        "durationMs": 8
+        "durationMs": 11
       },
       "oauthProtectedResource": {
         "status": "fail",
@@ -652,7 +652,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc88cbe7df0-SJO"
+                "cf-ray": "a36b98c3dced7df0-SJO"
               }
             },
             "finding": {
@@ -672,7 +672,7 @@
               "statusText": "OK",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc88cbf7df0-SJO"
+                "cf-ray": "a36b98c3dcf07df0-SJO"
               }
             },
             "finding": {
@@ -689,7 +689,7 @@
             }
           }
         ],
-        "durationMs": 35
+        "durationMs": 28
       },
       "authMd": {
         "status": "fail",
@@ -710,7 +710,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc88cc17df0-SJO"
+                "cf-ray": "a36b98c3dcf17df0-SJO"
               }
             },
             "finding": {
@@ -727,7 +727,7 @@
             }
           }
         ],
-        "durationMs": 36
+        "durationMs": 29
       },
       "mcpServerCard": {
         "status": "fail",
@@ -745,7 +745,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc89cc47df0-SJO"
+                "cf-ray": "a36b98c3dcf27df0-SJO"
               }
             },
             "finding": {
@@ -765,7 +765,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc89cc57df0-SJO"
+                "cf-ray": "a36b98c3ecf47df0-SJO"
               }
             },
             "finding": {
@@ -785,7 +785,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc89cc67df0-SJO"
+                "cf-ray": "a36b98c3ecf67df0-SJO"
               }
             },
             "finding": {
@@ -802,7 +802,7 @@
             }
           }
         ],
-        "durationMs": 37
+        "durationMs": 31
       },
       "a2aAgentCard": {
         "status": "fail",
@@ -820,7 +820,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc89cc87df0-SJO"
+                "cf-ray": "a36b98c3ecf77df0-SJO"
               }
             },
             "finding": {
@@ -837,7 +837,7 @@
             }
           }
         ],
-        "durationMs": 38
+        "durationMs": 32
       },
       "agentSkills": {
         "status": "fail",
@@ -855,7 +855,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8bcd87df0-SJO"
+                "cf-ray": "a36b98c40cfc7df0-SJO"
               }
             },
             "finding": {
@@ -875,7 +875,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8ecee7df0-SJO"
+                "cf-ray": "a36b98c43d127df0-SJO"
               }
             },
             "finding": {
@@ -892,7 +892,7 @@
             }
           }
         ],
-        "durationMs": 77
+        "durationMs": 87
       },
       "webMcp": {
         "status": "fail",
@@ -935,7 +935,7 @@
             }
           }
         ],
-        "durationMs": 4036
+        "durationMs": 4056
       },
       "ard": {
         "status": "fail",
@@ -972,7 +972,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc88cb77df0-SJO"
+                "cf-ray": "a36b98c3dce87df0-SJO"
               }
             },
             "finding": {
@@ -996,7 +996,7 @@
               "headers": {
                 "content-type": "application/dns-json"
               },
-              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_catalog._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_catalog._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
             },
             "finding": {
               "outcome": "neutral",
@@ -1019,7 +1019,7 @@
               "headers": {
                 "content-type": "application/dns-json"
               },
-              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_search._agents.vet24cr.com\",\"type\":33}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_search._agents.vet24cr.com\",\"type\":33}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
             },
             "finding": {
               "outcome": "neutral",
@@ -1039,7 +1039,7 @@
           "discoveryMechanisms": [],
           "searchEndpoints": []
         },
-        "durationMs": 7
+        "durationMs": 9
       }
     },
     "commerce": {
@@ -1059,7 +1059,7 @@
               "statusText": "OK",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8cce17df0-SJO"
+                "cf-ray": "a36b98c40d007df0-SJO"
               }
             },
             "finding": {
@@ -1079,7 +1079,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8ecef7df0-SJO"
+                "cf-ray": "a36b98c43d147df0-SJO"
               }
             },
             "finding": {
@@ -1099,7 +1099,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8ecf07df0-SJO"
+                "cf-ray": "a36b98c43d137df0-SJO"
               }
             },
             "finding": {
@@ -1119,7 +1119,7 @@
               "statusText": "OK",
               "headers": {
                 "content-type": "application/json",
-                "cf-ray": "a36b1bc8cce07df0-SJO"
+                "cf-ray": "a36b98c40cff7df0-SJO"
               }
             }
           },
@@ -1144,7 +1144,7 @@
             }
           }
         ],
-        "durationMs": 524
+        "durationMs": 948
       },
       "mpp": {
         "status": "neutral",
@@ -1162,7 +1162,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8cce57df0-SJO"
+                "cf-ray": "a36b98c40d057df0-SJO"
               }
             },
             "finding": {
@@ -1179,7 +1179,7 @@
             }
           }
         ],
-        "durationMs": 60
+        "durationMs": 64
       },
       "ucp": {
         "status": "neutral",
@@ -1197,7 +1197,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8ccdf7df0-SJO"
+                "cf-ray": "a36b98c40cfe7df0-SJO"
               }
             },
             "finding": {
@@ -1214,7 +1214,7 @@
             }
           }
         ],
-        "durationMs": 42
+        "durationMs": 34
       },
       "acp": {
         "status": "neutral",
@@ -1232,7 +1232,7 @@
               "statusText": "Not Found",
               "headers": {
                 "content-type": "text/html",
-                "cf-ray": "a36b1bc8cce67df0-SJO"
+                "cf-ray": "a36b98c40d067df0-SJO"
               }
             },
             "finding": {
@@ -1249,7 +1249,7 @@
             }
           }
         ],
-        "durationMs": 60
+        "durationMs": 65
       },
       "ap2": {
         "status": "neutral",

--- a/docs/agent-readiness/evidencia/ar2/scan-pre-deploy.json
+++ b/docs/agent-readiness/evidencia/ar2/scan-pre-deploy.json
@@ -1,0 +1,1290 @@
+{
+  "url": "https://vet24cr.com",
+  "targetUrl": "https://vet24cr.com",
+  "scannedAt": "2026-09-06T05:35:13.490Z",
+  "level": 2,
+  "levelName": "Bot-Aware",
+  "checks": {
+    "discoverability": {
+      "robotsTxt": {
+        "status": "pass",
+        "message": "robots.txt exists with valid format",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /robots.txt",
+            "request": {
+              "url": "https://vet24cr.com/robots.txt",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/plain",
+                "content-length": "125",
+                "cf-ray": "a36b1bc85cae7df0-SJO"
+              },
+              "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received valid robots.txt (200, text/plain)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Validate robots.txt structure",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Contains valid User-agent directive(s)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "robots.txt exists with valid format"
+            }
+          }
+        ],
+        "durationMs": 0
+      },
+      "sitemap": {
+        "status": "pass",
+        "message": "sitemap.xml exists with valid structure",
+        "details": {
+          "url": "https://vet24cr.com/sitemap-index.xml",
+          "fromRobotsTxt": true,
+          "format": "xml"
+        },
+        "evidence": [
+          {
+            "action": "parse",
+            "label": "Extract Sitemap directives from robots.txt",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found 1 Sitemap directive(s) in robots.txt"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /sitemap-index.xml",
+            "request": {
+              "url": "https://vet24cr.com/sitemap-index.xml",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/xml",
+                "content-length": "182",
+                "cf-ray": "a36b1bc88cba7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found valid xml sitemap at https://vet24cr.com/sitemap-index.xml"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "sitemap.xml exists with valid structure"
+            }
+          }
+        ],
+        "durationMs": 8
+      },
+      "linkHeaders": {
+        "status": "fail",
+        "message": "No Link headers found on target page",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8eced7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "No Link header present in response"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No Link headers found on target page"
+            }
+          }
+        ],
+        "durationMs": 76
+      },
+      "dnsAid": {
+        "status": "fail",
+        "message": "DNS for AI Discovery (DNS-AID) well-known entrypoint records not found",
+        "details": {
+          "domainsChecked": [
+            "vet24cr.com"
+          ],
+          "queriesAttempted": [
+            "SVCB _index._agents.vet24cr.com",
+            "HTTPS _index._agents.vet24cr.com",
+            "SVCB _a2a._agents.vet24cr.com",
+            "HTTPS _a2a._agents.vet24cr.com",
+            "SVCB _mcp._agents.vet24cr.com",
+            "HTTPS _mcp._agents.vet24cr.com",
+            "TXT _index._agents.vet24cr.com"
+          ],
+          "dnssecValidated": false,
+          "serviceRecordCount": 0,
+          "aliasRecordCount": 0,
+          "txtIndexEntryCount": 0,
+          "txtIndexEntries": [],
+          "records": []
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "DoH SVCB _index._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_index._agents.vet24cr.com&type=SVCB&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SVCB answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH HTTPS _index._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_index._agents.vet24cr.com&type=HTTPS&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No HTTPS answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH SVCB _a2a._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_a2a._agents.vet24cr.com&type=SVCB&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SVCB answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH HTTPS _a2a._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_a2a._agents.vet24cr.com&type=HTTPS&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No HTTPS answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH SVCB _mcp._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_mcp._agents.vet24cr.com&type=SVCB&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SVCB answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH HTTPS _mcp._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_mcp._agents.vet24cr.com&type=HTTPS&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No HTTPS answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH TXT _index._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_index._agents.vet24cr.com&type=TXT&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No TXT answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Parse DNS for AI Discovery (DNS-AID) SVCB/HTTPS records",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No DNS for AI Discovery (DNS-AID) SVCB or HTTPS records found at well-known entrypoints"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "DNS for AI Discovery (DNS-AID) well-known entrypoint records not found"
+            }
+          }
+        ],
+        "durationMs": 2
+      }
+    },
+    "contentAccessibility": {
+      "markdownNegotiation": {
+        "status": "fail",
+        "message": "Site does not support Markdown for Agents",
+        "details": {
+          "contentType": "text/html"
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET target page (Accept: text/markdown)",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET",
+              "headers": {
+                "accept": "text/markdown",
+                "cache-control": "no-cache"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Response content-type is text/html, not text/markdown -- site does not support markdown content negotiation"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bd53db4bd73-MIA"
+              }
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "Site does not support Markdown for Agents"
+            }
+          }
+        ],
+        "durationMs": 593
+      }
+    },
+    "botAccessControl": {
+      "robotsTxtAiRules": {
+        "status": "pass",
+        "message": "No AI-specific bot rules; wildcard rules apply to all crawlers including AI bots",
+        "details": {
+          "checkedBots": [
+            "gptbot",
+            "chatgpt-user",
+            "google-extended",
+            "ccbot",
+            "anthropic-ai",
+            "claude-web",
+            "bytespider",
+            "perplexitybot",
+            "cohere-ai",
+            "applebot-extended",
+            "amazonbot",
+            "meta-externalagent",
+            "facebookbot",
+            "omgilibot",
+            "diffbot"
+          ]
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /robots.txt",
+            "request": {
+              "url": "https://vet24cr.com/robots.txt",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/plain",
+                "content-length": "125",
+                "cf-ray": "a36b1bc85cae7df0-SJO"
+              },
+              "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received valid robots.txt (200, text/plain)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Scan for AI bot User-agent directives",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Checked 15 AI bot user agents -- none found, but wildcard rules apply"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "No AI-specific bot rules; wildcard rules apply to all crawlers including AI bots"
+            }
+          }
+        ],
+        "durationMs": 0
+      },
+      "contentSignals": {
+        "status": "pass",
+        "message": "Content Signals found in robots.txt",
+        "details": {
+          "signals": [
+            {
+              "userAgent": "*",
+              "path": null,
+              "aiTrain": "no",
+              "search": "yes",
+              "aiInput": "yes"
+            }
+          ],
+          "signalCount": 1
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /robots.txt",
+            "request": {
+              "url": "https://vet24cr.com/robots.txt",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/plain",
+                "content-length": "125",
+                "cf-ray": "a36b1bc85cae7df0-SJO"
+              },
+              "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received valid robots.txt (200, text/plain)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Parse Content-Signal directives",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found 1 Content-Signal directive(s)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Content Signals found in robots.txt"
+            }
+          }
+        ],
+        "durationMs": 0
+      },
+      "webBotAuth": {
+        "status": "neutral",
+        "message": "Web Bot Auth directory not found (informational only)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/http-message-signatures-directory",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/http-message-signatures-directory",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc88cbc7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- Web Bot Auth directory not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "Web Bot Auth directory not found"
+            }
+          }
+        ],
+        "durationMs": 6
+      }
+    },
+    "discovery": {
+      "apiCatalog": {
+        "status": "fail",
+        "message": "API Catalog not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/api-catalog",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/api-catalog",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/linkset+json, application/json"
+              }
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8bcdb7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- API Catalog not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "API Catalog not found"
+            }
+          }
+        ],
+        "durationMs": 41
+      },
+      "oauthDiscovery": {
+        "status": "fail",
+        "message": "No OAuth/OIDC discovery metadata found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/openid-configuration",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/openid-configuration",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc88cbb7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "openid-configuration returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/oauth-authorization-server",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/oauth-authorization-server",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc88cbd7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "oauth-authorization-server returned 404"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No OAuth/OIDC discovery metadata found at either well-known path"
+            }
+          }
+        ],
+        "durationMs": 8
+      },
+      "oauthProtectedResource": {
+        "status": "fail",
+        "message": "No OAuth Protected Resource Metadata found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/oauth-protected-resource",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/oauth-protected-resource",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc88cbe7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc88cbf7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Target resource returned 200 (no WWW-Authenticate header)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No OAuth Protected Resource Metadata found"
+            }
+          }
+        ],
+        "durationMs": 35
+      },
+      "authMd": {
+        "status": "fail",
+        "message": "auth.md not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /auth.md",
+            "request": {
+              "url": "https://vet24cr.com/auth.md",
+              "method": "GET",
+              "headers": {
+                "Accept": "text/markdown, text/plain, */*"
+              }
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc88cc17df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 - auth.md not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "auth.md not found"
+            }
+          }
+        ],
+        "durationMs": 36
+      },
+      "mcpServerCard": {
+        "status": "fail",
+        "message": "MCP Server Card not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/mcp/server-card.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/mcp/server-card.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc89cc47df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "/.well-known/mcp/server-card.json returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/mcp/server-cards.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/mcp/server-cards.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc89cc57df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "/.well-known/mcp/server-cards.json returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/mcp.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/mcp.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc89cc67df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "/.well-known/mcp.json returned 404"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "MCP Server Card not found at any candidate path"
+            }
+          }
+        ],
+        "durationMs": 37
+      },
+      "a2aAgentCard": {
+        "status": "fail",
+        "message": "A2A Agent Card not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/agent-card.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/agent-card.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc89cc87df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- A2A Agent Card not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "A2A Agent Card not found"
+            }
+          }
+        ],
+        "durationMs": 38
+      },
+      "agentSkills": {
+        "status": "fail",
+        "message": "Agent Skills index not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/agent-skills/index.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/agent-skills/index.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8bcd87df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "v0.2.0 path returned 404 — trying legacy path"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/skills/index.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/skills/index.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8ecee7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 — Agent Skills index not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "Agent Skills index not found"
+            }
+          }
+        ],
+        "durationMs": 77
+      },
+      "webMcp": {
+        "status": "fail",
+        "message": "No WebMCP tools detected on page load",
+        "evidence": [
+          {
+            "action": "parse",
+            "label": "WebMCP detection",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Checking page for WebMCP tool registrations"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "Navigate to https://vet24cr.com",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Loading page to detect WebMCP tool registrations"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Check imperative WebMCP API",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No tools registered via navigator.modelContext"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No WebMCP tools detected on page load"
+            }
+          }
+        ],
+        "durationMs": 4036
+      },
+      "ard": {
+        "status": "fail",
+        "message": "ARD capability manifest not found",
+        "evidence": [
+          {
+            "action": "parse",
+            "label": "Extract Agentmap directives from robots.txt",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No Agentmap directives found"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Extract <link rel=\"ai-catalog\"> from page head",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No catalog links found"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/ai-catalog.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/ai-catalog.json",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/json"
+              }
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc88cb77df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- ai-catalog.json not found"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH TXT _catalog._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_catalog._agents.vet24cr.com&type=TXT&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_catalog._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No TXT answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH SRV _search._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_search._agents.vet24cr.com&type=SRV&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_search._agents.vet24cr.com\",\"type\":33}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1787,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SRV answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "ARD capability manifest not found"
+            }
+          }
+        ],
+        "details": {
+          "discoveryMechanisms": [],
+          "searchEndpoints": []
+        },
+        "durationMs": 7
+      }
+    },
+    "commerce": {
+      "x402": {
+        "status": "neutral",
+        "message": "x402 payment protocol not detected (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /",
+            "request": {
+              "url": "https://vet24cr.com/",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8cce17df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/ returned 200 (not 402)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /api/v1",
+            "request": {
+              "url": "https://vet24cr.com/api/v1",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8ecef7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/api/v1 returned 404 (not 402)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /api",
+            "request": {
+              "url": "https://vet24cr.com/api",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8ecf07df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/api returned 404 (not 402)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /platform/v2/x402/discovery/resources",
+            "request": {
+              "url": "https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources?limit=500",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/json",
+                "cf-ray": "a36b1bc8cce07df0-SJO"
+              }
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET Bazaar discovery API",
+            "request": {
+              "url": "https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources?limit=500",
+              "method": "GET"
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Network error querying Bazaar API"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "x402 payment protocol not detected"
+            }
+          }
+        ],
+        "durationMs": 524
+      },
+      "mpp": {
+        "status": "neutral",
+        "message": "MPP payment discovery not detected (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /openapi.json",
+            "request": {
+              "url": "https://vet24cr.com/openapi.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8cce57df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/openapi.json returned 404"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "MPP payment discovery not detected"
+            }
+          }
+        ],
+        "durationMs": 60
+      },
+      "ucp": {
+        "status": "neutral",
+        "message": "UCP profile not found (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/ucp",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/ucp",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8ccdf7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- UCP profile not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "UCP profile not found"
+            }
+          }
+        ],
+        "durationMs": 42
+      },
+      "acp": {
+        "status": "neutral",
+        "message": "ACP discovery document not found (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/acp.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/acp.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36b1bc8cce67df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- ACP discovery document not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "ACP discovery document not found"
+            }
+          }
+        ],
+        "durationMs": 60
+      },
+      "ap2": {
+        "status": "neutral",
+        "message": "AP2 not detected (no A2A Agent Card) (not a commerce site)",
+        "evidence": [
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No A2A Agent Card found -- AP2 requires an A2A Agent Card"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "nextLevel": {
+    "target": 3,
+    "name": "Agent-Readable",
+    "requirements": [
+      {
+        "check": "markdownNegotiation",
+        "description": "Support Accept: text/markdown content negotiation for machine-readable content",
+        "shortPrompt": "Enable Markdown for Agents so requests with Accept: text/markdown return a markdown version of your HTML.",
+        "specUrls": [
+          "https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/"
+        ],
+        "prompt": "Implement content negotiation so requests with Accept: text/markdown return a markdown representation while HTML remains the default for browsers.",
+        "skillUrl": "https://isitagentready.com/.well-known/agent-skills/markdown-negotiation/SKILL.md"
+      }
+    ]
+  },
+  "isCommerce": false,
+  "commerceSignals": [
+    "url:/cart"
+  ]
+}

--- a/docs/agent-readiness/evidencia/ar2/verification-common.json
+++ b/docs/agent-readiness/evidencia/ar2/verification-common.json
@@ -1,0 +1,21 @@
+{
+  "baseSha": "06cab06db0e3ffca2f5b314276af5dda4b831db7",
+  "branch": "ar2/catalog-discovery",
+  "commands": {
+    "npm ci": { "exitCode": 0 },
+    "npm run build:no-shorten": { "exitCode": 0, "note": "Wrangler emitió una advertencia de certificado al consultar Request.cf; el build terminó correctamente." },
+    "node scripts/verification/agent-catalog.mjs": { "exitCode": 0, "clinics": 112, "clinicHtmlRoutes": 112 },
+    "npm run types:worker": { "exitCode": 0 },
+    "git diff --exit-code -- worker-configuration.d.ts": { "exitCode": 0 },
+    "npm run check": { "exitCode": 0, "errors": 0, "warnings": 0, "hints": 73 },
+    "npm test": { "exitCode": 0, "passed": 41 },
+    "npm run deploy:dry-run": { "exitCode": 0 },
+    "npm run test:e2e": { "exitCode": 1, "note": "La ejecución paralela local con 8 workers saturó el preview y produjo 17 timeouts; no se acepta como resultado funcional." },
+    "npx playwright test --workers=1": { "exitCode": 0, "passed": 77, "skipped": 11, "note": "Corrida serial equivalente al modo CI; los 11 skips son históricos." },
+    "npx playwright test tests/e2e/agent-discovery.spec.ts --workers=1": { "exitCode": 0, "passed": 5 },
+    "git diff --check": { "exitCode": 0 },
+    "allowlist": { "exitCode": 0 }
+  },
+  "preDeployScan": "scan-pre-deploy.json",
+  "productionVerification": "Pendiente de sesión verificadora distinta y de despliegue; esta sesión no fusiona ni cierra AR2."
+}

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,9 @@
+{
+  "anchor": "https://vet24cr.com/api/catalog.json",
+  "service-desc": [
+    { "href": "https://vet24cr.com/api/openapi.json" }
+  ],
+  "service-doc": [
+    { "href": "https://vet24cr.com/api/readme.md" }
+  ]
+}

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,38 @@
+/*
+  Access-Control-Allow-Methods: GET, HEAD
+
+/api/catalog.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+
+/api/openapi.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+
+/llms.txt
+  Content-Type: text/plain; charset=utf-8
+  Access-Control-Allow-Origin: *
+
+/api/readme.md
+  Content-Type: text/markdown; charset=utf-8
+  Access-Control-Allow-Origin: *
+
+/auth.md
+  Content-Type: text/markdown; charset=utf-8
+  Access-Control-Allow-Origin: *
+
+/.well-known/api-catalog
+  Content-Type: application/linkset+json; charset=utf-8
+  Access-Control-Allow-Origin: *
+
+/
+  Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"
+
+/clinica/*
+  Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"
+
+/provincia/*
+  Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"
+
+/zona/*
+  Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/sitemap.xml /sitemap-index.xml 301

--- a/public/api/readme.md
+++ b/public/api/readme.md
@@ -1,0 +1,44 @@
+# API pública de Vet24-cr
+
+`GET https://vet24cr.com/api/catalog.json` devuelve el catálogo completo de clínicas publicado por Vet24-cr.
+
+## Forma del documento
+
+- `schemaVersion`: versión del contrato (`"1"`).
+- `timeZone`: `America/Costa_Rica`.
+- `clinics`: todas las fichas que también tienen una ruta HTML `/clinica/<slug>/`, ordenadas por `slug`.
+- `url`: URL canónica absoluta de la ficha HTML.
+- `provinciaSlug` y `zonaSlug`: slugs calculados con las reglas del sitio.
+- `openNow`: siempre `null`; este catálogo no informa disponibilidad en tiempo real.
+- `latitude` y `longitude`: ambas `null` si falta una coordenada, no es válida o la pareja es `0/0`.
+- Campos de contacto: el valor registrado o `null` si está vacío; no todos son URLs validadas.
+- `copyDiferenciador`, `bodyMarkdown` y `verification_notes`: se conservan íntegramente, incluidas restricciones de especie, horario o reserva.
+- `capacidades`: cada capacidad tiene `valorRegistrado` y `estado`; `afirmado` significa que el booleano está registrado como verdadero, mientras `no-confirmado` no significa que el servicio no exista.
+- `advertencias`: límites de interpretación que acompañan cada ficha.
+
+El catálogo es anónimo, estático y de solo lectura. No ofrece filtros, paginación, búsquedas HTTP ni una certificación de horarios. Descarga el JSON y filtra localmente; confirma por teléfono antes de trasladarte.
+
+## Ejemplos de consultas locales
+
+Emergencias registradas en Heredia:
+
+```js
+const catalog = await fetch('https://vet24cr.com/api/catalog.json').then((r) => r.json());
+const opciones = catalog.clinics.filter(
+  (clinic) => clinic.provinciaSlug === 'heredia' && clinic.capacidades.emergencias24h.estado === 'afirmado',
+);
+```
+
+Clínicas de una zona para confirmar si están abiertas:
+
+```js
+const catalog = await fetch('https://vet24cr.com/api/catalog.json').then((r) => r.json());
+const opciones = catalog.clinics.filter((clinic) => clinic.zonaSlug === 'guapiles');
+// Usa horarioTexto y contacto; openNow es null y se debe confirmar por teléfono.
+```
+
+## Documentación
+
+- OpenAPI: https://vet24cr.com/api/openapi.json
+- API Catalog: https://vet24cr.com/.well-known/api-catalog
+- Índice breve para agentes: https://vet24cr.com/llms.txt

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,0 +1,9 @@
+# auth.md
+
+El catálogo público de Vet24-cr es anónimo y de solo lectura. No requiere registro, API key, OAuth ni credenciales:
+
+- `GET https://vet24cr.com/api/catalog.json` devuelve el catálogo público.
+- No hay filtros ni paginación HTTP.
+- El endpoint no concede permisos para escribir, editar o reportar datos.
+
+Los horarios y capacidades son datos registrados con límites explícitos; confirma la atención por teléfono antes de trasladarte.

--- a/scripts/verification/agent-catalog.mjs
+++ b/scripts/verification/agent-catalog.mjs
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const repo = resolve(import.meta.dirname, "../..");
+const dist = join(repo, "dist");
+const errors = [];
+
+function walk(directory) {
+  if (!existsSync(directory)) return [];
+  const files = [];
+  for (const name of readdirSync(directory)) {
+    const path = join(directory, name);
+    if (statSync(path).isDirectory()) files.push(...walk(path));
+    else files.push(path);
+  }
+  return files;
+}
+
+const files = walk(dist);
+function findArtifact(pathname) {
+  const normalized = pathname.replace(/^\//, "");
+  const matches = files.filter((file) => {
+    const builtPath = relative(dist, file).replaceAll("\\", "/");
+    return builtPath === normalized || builtPath.endsWith(`/${normalized}`);
+  });
+  return matches[0];
+}
+
+function readArtifact(pathname, label = pathname) {
+  const file = findArtifact(pathname);
+  if (!file) {
+    errors.push(`missing artifact: ${pathname}`);
+    return null;
+  }
+  return readFileSync(file, "utf8");
+}
+
+const catalogText = readArtifact("api/catalog.json");
+const openapiText = readArtifact("api/openapi.json");
+const llmsText = readArtifact("llms.txt");
+const readmeText = readArtifact("api/readme.md");
+const authText = readArtifact("auth.md");
+const linksetText = readArtifact(".well-known/api-catalog");
+
+let catalog;
+let openapi;
+let linkset;
+try { catalog = JSON.parse(catalogText); } catch { errors.push("catalog is not valid JSON"); }
+try { openapi = JSON.parse(openapiText); } catch { errors.push("OpenAPI is not valid JSON"); }
+try { linkset = JSON.parse(linksetText); } catch { errors.push("API Catalog is not valid JSON"); }
+
+if (catalog) {
+  if (catalog.schemaVersion !== "1") errors.push("catalog schemaVersion must be 1");
+  if (catalog.timeZone !== "America/Costa_Rica") errors.push("catalog timeZone mismatch");
+  if (!Array.isArray(catalog.clinics)) errors.push("catalog clinics must be an array");
+  const clinics = Array.isArray(catalog.clinics) ? catalog.clinics : [];
+  const slugs = clinics.map((clinic) => clinic.slug);
+  if (new Set(slugs).size !== slugs.length) errors.push("catalog slugs are not unique");
+  for (const clinic of clinics) {
+    if (!clinic.url || clinic.url !== `https://vet24cr.com/clinica/${clinic.slug}/`) errors.push(`bad URL for ${clinic.slug}`);
+    if (clinic.openNow !== null) errors.push(`openNow is not null for ${clinic.slug}`);
+    if (!Array.isArray(clinic.verification_notes)) errors.push(`verification_notes missing for ${clinic.slug}`);
+    if (!Array.isArray(clinic.advertencias) || clinic.advertencias.length !== 3) errors.push(`warnings missing for ${clinic.slug}`);
+    if (!clinic.capacidades || typeof clinic.capacidades !== "object") errors.push(`capacidades missing for ${clinic.slug}`);
+  }
+}
+
+if (openapi) {
+  if (openapi.openapi !== "3.1.0") errors.push("OpenAPI must be 3.1.0");
+  if (Object.keys(openapi.paths ?? {}).join() !== "/api/catalog.json") errors.push("OpenAPI describes an unexpected path");
+  const operation = openapi.paths?.["/api/catalog.json"]?.get;
+  if (!operation || operation.post || operation.parameters || operation.security) errors.push("OpenAPI catalog operation is not read-only and unfiltered");
+  if (!openapi.components?.schemas?.Catalog) errors.push("OpenAPI catalog schema missing");
+}
+
+if (linkset) {
+  if (linkset.anchor !== "https://vet24cr.com/api/catalog.json") errors.push("API Catalog anchor mismatch");
+  const desc = linkset["service-desc"]?.map((item) => item.href) ?? [];
+  const docs = linkset["service-doc"]?.map((item) => item.href) ?? [];
+  if (desc.length !== 1 || desc[0] !== "https://vet24cr.com/api/openapi.json") errors.push("API Catalog service-desc mismatch");
+  if (docs.length !== 1 || docs[0] !== "https://vet24cr.com/api/readme.md") errors.push("API Catalog service-doc mismatch");
+  if (Object.keys(linkset).some((key) => !["anchor", "service-desc", "service-doc"].includes(key))) errors.push("API Catalog contains unexpected relation");
+}
+
+if (llmsText && (!llmsText.startsWith("# Vet24-cr") || !llmsText.includes("/api/catalog.json") || !llmsText.includes("/api/readme.md"))) errors.push("llms.txt is missing required discovery links");
+if (readmeText && (!readmeText.startsWith("# API pública") || !readmeText.includes("Emergencias registradas en Heredia") || !readmeText.includes("`openNow`"))) errors.push("api/readme.md is missing the contract examples/limits");
+if (authText && !authText.startsWith("# auth.md")) errors.push("auth.md heading missing");
+
+const clinicHtml = files.filter((file) => /(?:^|[\\/])clinica[\\/][^\\/]+[\\/]index\.html$/.test(file));
+const htmlSlugs = clinicHtml.map((file) => relative(dist, file).replaceAll("\\", "/").match(/clinica\/([^/]+)\/index\.html$/)?.[1]).filter(Boolean);
+const catalogSlugs = catalog?.clinics?.map((clinic) => clinic.slug) ?? [];
+if (new Set(htmlSlugs).size !== new Set(catalogSlugs).size || [...new Set(htmlSlugs)].some((slug) => !catalogSlugs.includes(slug)) || [...new Set(catalogSlugs)].some((slug) => !htmlSlugs.includes(slug))) {
+  errors.push("catalog clinic set differs from built clinic HTML routes");
+}
+for (const file of clinicHtml) {
+  const slug = relative(dist, file).replaceAll("\\", "/").match(/clinica\/([^/]+)\/index\.html$/)?.[1];
+  if (slug && !readFileSync(file, "utf8").includes(`https://vet24cr.com/clinica/${slug}/`)) errors.push(`canonical URL missing in HTML for ${slug}`);
+}
+
+if (errors.length) {
+  console.error(errors.map((error) => `✗ ${error}`).join("\n"));
+  process.exitCode = 1;
+} else {
+  console.log(`✓ AR2 catalog artifacts valid (${catalog.clinics.length} clinics, ${clinicHtml.length} HTML routes)`);
+}

--- a/src/lib/agent-content.ts
+++ b/src/lib/agent-content.ts
@@ -1,0 +1,292 @@
+import { normalizeSlug, SITE_ORIGIN } from "./seo.ts";
+
+export const AGENT_TIME_ZONE = "America/Costa_Rica";
+
+export const AGENT_WARNINGS = [
+  "Confirma por teléfono el horario y la atención antes de trasladarte; este catálogo no informa disponibilidad en tiempo real.",
+  "Una capacidad afirmada refleja lo registrado en la ficha; no confirmado no significa que el servicio no exista.",
+  "Lee las notas y el texto de la ficha: los servicios pueden tener restricciones de especie, horario o reserva.",
+] as const;
+
+export const CAPABILITY_KEYS = [
+  "emergencias24h",
+  "atiendeExoticos",
+  "cirugiaEmergencia",
+  "atiendeGranja",
+  "atiendePeces",
+  "hotelMascotas",
+  "has_surgery",
+  "has_hospitalization",
+  "overnight_doctor_present",
+  "accepts_emergency_walkins",
+] as const;
+
+// Keep the catalog's zone normalization aligned with getClinicZoneSlug from
+// zones.ts. This local lookup also keeps the pure adapter importable by the
+// repository's plain node:test runner, which does not resolve Astro's
+// extensionless internal imports.
+const ZONE_ALIASES: Record<string, string> = {
+  guapiles: "guapiles",
+  "san-pablo-de-heredia": "san-pablo-heredia",
+  "san-pablo-heredia": "san-pablo-heredia",
+  grecia: "grecia",
+  "grecia-centro": "grecia",
+  nicoya: "nicoya",
+  "nicoya-centro": "nicoya",
+  "san-ramon": "san-ramon",
+  "san-ramon-centro": "san-ramon",
+  curridabat: "curridabat",
+  siquirres: "siquirres",
+};
+
+type CapabilityKey = (typeof CAPABILITY_KEYS)[number];
+
+export interface AgentClinicData {
+  [key: string]: unknown;
+  id?: number | string;
+  nombre?: string;
+  provincia?: string;
+  zona?: string;
+  direccion?: string;
+  telefono1?: string;
+  telefono2?: string;
+  whatsapp?: string;
+  horarioTexto?: string;
+  categoriaHorario?: string;
+  emergencias24h?: boolean;
+  atiendeExoticos?: boolean;
+  cirugiaEmergencia?: boolean;
+  atiendeGranja?: boolean;
+  atiendePeces?: boolean;
+  hotelMascotas?: boolean;
+  hotelVerificacion?: string;
+  hotelFuente?: string;
+  confidence_score?: string;
+  record_status?: string;
+  emergency_tier?: string;
+  last_verified?: string;
+  phone_verified?: boolean;
+  address_verified?: boolean;
+  schedule_verified?: boolean;
+  emergency_verified?: boolean;
+  has_surgery?: boolean;
+  has_hospitalization?: boolean;
+  overnight_doctor_present?: boolean;
+  accepts_emergency_walkins?: boolean;
+  verification_notes?: string[];
+  verification_source?: string;
+  latitude?: number;
+  longitude?: number;
+  waze_url?: string;
+  maps_url?: string;
+  web?: string;
+  facebook?: string;
+  instagram?: string;
+  slug?: string;
+  estado?: string;
+  copyDiferenciador?: string;
+}
+
+export interface AgentClinicEntry {
+  data: AgentClinicData;
+  body?: string;
+}
+
+export interface AgentClinic {
+  slug: string;
+  url: string;
+  nombre: string | null;
+  provincia: string | null;
+  zona: string | null;
+  direccion: string | null;
+  provinciaSlug: string | null;
+  zonaSlug: string | null;
+  telefono1: string | null;
+  telefono2: string | null;
+  whatsapp: string | null;
+  web: string | null;
+  facebook: string | null;
+  instagram: string | null;
+  waze_url: string | null;
+  maps_url: string | null;
+  horarioTexto: string | null;
+  categoriaHorario: string | null;
+  openNow: null;
+  latitude: number | null;
+  longitude: number | null;
+  copyDiferenciador: string | null;
+  bodyMarkdown: string;
+  estado: string | null;
+  confidence_score: string | null;
+  record_status: string | null;
+  emergency_tier: string | null;
+  last_verified: string | null;
+  verification_source: string | null;
+  hotelFuente: string | null;
+  verification_notes: string[];
+  phone_verified: boolean;
+  address_verified: boolean;
+  schedule_verified: boolean;
+  emergency_verified: boolean;
+  hotelVerificacion: string | null;
+  capacidades: Record<CapabilityKey, { valorRegistrado: boolean; estado: "afirmado" | "no-confirmado" }>;
+  advertencias: readonly string[];
+}
+
+function nullableText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
+function registeredBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function agentZoneSlug(zona: string): string {
+  const normalized = normalizeSlug(zona);
+  return ZONE_ALIASES[normalized] ?? normalized;
+}
+
+function capability(value: unknown) {
+  const valorRegistrado = registeredBoolean(value);
+  return { valorRegistrado, estado: valorRegistrado ? "afirmado" as const : "no-confirmado" as const };
+}
+
+function validCoordinates(data: AgentClinicData): [number | null, number | null] {
+  const latitude = data.latitude;
+  const longitude = data.longitude;
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude) || (latitude === 0 && longitude === 0)) {
+    return [null, null];
+  }
+  return [latitude as number, longitude as number];
+}
+
+export function toAgentClinic(entry: AgentClinicEntry): AgentClinic {
+  const data = entry.data;
+  const slug = typeof data.slug === "string" ? data.slug : "";
+  const [latitude, longitude] = validCoordinates(data);
+  const capacidades = Object.fromEntries(
+    CAPABILITY_KEYS.map((key) => [key, capability(data[key])]),
+  ) as AgentClinic["capacidades"];
+
+  return {
+    slug,
+    url: `${SITE_ORIGIN}/clinica/${slug}/`,
+    nombre: nullableText(data.nombre),
+    provincia: nullableText(data.provincia),
+    zona: nullableText(data.zona),
+    direccion: nullableText(data.direccion),
+    provinciaSlug: typeof data.provincia === "string" ? normalizeSlug(data.provincia) : null,
+    zonaSlug: typeof data.zona === "string" ? agentZoneSlug(data.zona) : null,
+    telefono1: nullableText(data.telefono1),
+    telefono2: nullableText(data.telefono2),
+    whatsapp: nullableText(data.whatsapp),
+    web: nullableText(data.web),
+    facebook: nullableText(data.facebook),
+    instagram: nullableText(data.instagram),
+    waze_url: nullableText(data.waze_url),
+    maps_url: nullableText(data.maps_url),
+    horarioTexto: nullableText(data.horarioTexto),
+    categoriaHorario: nullableText(data.categoriaHorario),
+    openNow: null,
+    latitude,
+    longitude,
+    copyDiferenciador: nullableText(data.copyDiferenciador),
+    bodyMarkdown: typeof entry.body === "string" ? entry.body : "",
+    estado: nullableText(data.estado),
+    confidence_score: nullableText(data.confidence_score),
+    record_status: nullableText(data.record_status),
+    emergency_tier: nullableText(data.emergency_tier),
+    last_verified: nullableText(data.last_verified),
+    verification_source: nullableText(data.verification_source),
+    hotelFuente: nullableText(data.hotelFuente),
+    verification_notes: Array.isArray(data.verification_notes) ? [...data.verification_notes] : [],
+    phone_verified: data.phone_verified === true,
+    address_verified: data.address_verified === true,
+    schedule_verified: data.schedule_verified === true,
+    emergency_verified: data.emergency_verified === true,
+    hotelVerificacion: nullableText(data.hotelVerificacion),
+    capacidades,
+    advertencias: AGENT_WARNINGS,
+  };
+}
+
+export function buildAgentCatalog(entries: AgentClinicEntry[]) {
+  return {
+    schemaVersion: "1" as const,
+    timeZone: AGENT_TIME_ZONE,
+    clinics: entries.map(toAgentClinic).sort((a, b) => a.slug.localeCompare(b.slug)),
+  };
+}
+
+export const agentClinicOpenApiSchema = {
+  type: "object",
+  required: [
+    "slug", "url", "nombre", "provincia", "zona", "direccion", "provinciaSlug", "zonaSlug",
+    "telefono1", "telefono2", "whatsapp", "web", "facebook", "instagram", "waze_url", "maps_url",
+    "horarioTexto", "categoriaHorario", "openNow", "latitude", "longitude", "copyDiferenciador",
+    "bodyMarkdown", "estado", "confidence_score", "record_status", "emergency_tier", "last_verified",
+    "verification_source", "hotelFuente", "verification_notes", "phone_verified", "address_verified",
+    "schedule_verified", "emergency_verified", "hotelVerificacion", "capacidades", "advertencias",
+  ],
+  properties: {
+    slug: { type: "string" },
+    url: { type: "string", format: "uri" },
+    nombre: { type: ["string", "null"] },
+    provincia: { type: ["string", "null"] },
+    zona: { type: ["string", "null"] },
+    direccion: { type: ["string", "null"] },
+    provinciaSlug: { type: ["string", "null"] },
+    zonaSlug: { type: ["string", "null"] },
+    telefono1: { type: ["string", "null"] },
+    telefono2: { type: ["string", "null"] },
+    whatsapp: { type: ["string", "null"] },
+    web: { type: ["string", "null"] },
+    facebook: { type: ["string", "null"] },
+    instagram: { type: ["string", "null"] },
+    waze_url: { type: ["string", "null"] },
+    maps_url: { type: ["string", "null"] },
+    horarioTexto: { type: ["string", "null"] },
+    categoriaHorario: { type: ["string", "null"] },
+    openNow: { type: "null" },
+    latitude: { type: ["number", "null"] },
+    longitude: { type: ["number", "null"] },
+    copyDiferenciador: { type: ["string", "null"] },
+    bodyMarkdown: { type: "string" },
+    estado: { type: ["string", "null"] },
+    confidence_score: { type: ["string", "null"] },
+    record_status: { type: ["string", "null"] },
+    emergency_tier: { type: ["string", "null"] },
+    last_verified: { type: ["string", "null"] },
+    verification_source: { type: ["string", "null"] },
+    hotelFuente: { type: ["string", "null"] },
+    verification_notes: { type: "array", items: { type: "string" } },
+    phone_verified: { type: "boolean" },
+    address_verified: { type: "boolean" },
+    schedule_verified: { type: "boolean" },
+    emergency_verified: { type: "boolean" },
+    hotelVerificacion: { type: ["string", "null"] },
+    capacidades: {
+      type: "object",
+      required: [...CAPABILITY_KEYS],
+      properties: Object.fromEntries(CAPABILITY_KEYS.map((key) => [key, {
+        type: "object",
+        required: ["valorRegistrado", "estado"],
+        properties: {
+          valorRegistrado: { type: "boolean" },
+          estado: { type: "string", enum: ["afirmado", "no-confirmado"] },
+        },
+      }])),
+    },
+    advertencias: { type: "array", items: { type: "string", enum: [...AGENT_WARNINGS] } },
+  },
+} as const;
+
+export const agentCatalogOpenApiSchema = {
+  type: "object",
+  required: ["schemaVersion", "timeZone", "clinics"],
+  properties: {
+    schemaVersion: { type: "string", const: "1" },
+    timeZone: { type: "string", const: AGENT_TIME_ZONE },
+    clinics: { type: "array", items: agentClinicOpenApiSchema },
+  },
+} as const;

--- a/src/lib/agent-discovery.ts
+++ b/src/lib/agent-discovery.ts
@@ -1,0 +1,5 @@
+export const AGENT_LINK_HEADER = '</.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"';
+
+export function isAgentDiscoverableHtmlPath(pathname: string): boolean {
+  return pathname === "/" || /^\/(clinica|provincia|zona)\//.test(pathname);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,21 +1,28 @@
 import { defineMiddleware } from "astro:middleware";
+import { AGENT_LINK_HEADER, isAgentDiscoverableHtmlPath } from "./lib/agent-discovery";
 
 const CANONICAL_HOST = "vet24cr.com";
 
-export const onRequest = defineMiddleware((context, next) => {
+export const onRequest = defineMiddleware(async (context, next) => {
   const url = new URL(context.request.url);
   const isLocalHost = url.hostname === "localhost" || url.hostname === "127.0.0.1";
   if (isLocalHost) {
-    return next();
+    const response = await next();
+    if (!isAgentDiscoverableHtmlPath(url.pathname)) return response;
+    const headers = new Headers(response.headers);
+    headers.set("Link", AGENT_LINK_HEADER);
+    return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
   }
 
   const isCanonicalHost = url.hostname === CANONICAL_HOST;
   const isHttps = url.protocol === "https:";
   const hasIndex = url.pathname.endsWith("/index.html");
+  const isApiCatalog = url.pathname === "/.well-known/api-catalog";
   const needsSlash =
     !url.pathname.endsWith("/") &&
     !url.pathname.includes(".") &&
-    url.pathname !== "";
+    url.pathname !== "" &&
+    !isApiCatalog;
 
   if (!isCanonicalHost || !isHttps || hasIndex || needsSlash) {
     url.protocol = "https:";
@@ -32,5 +39,11 @@ export const onRequest = defineMiddleware((context, next) => {
     return Response.redirect(url, 301);
   }
 
-  return next();
+  const response = await next();
+  if (isAgentDiscoverableHtmlPath(url.pathname)) {
+    const headers = new Headers(response.headers);
+    headers.set("Link", AGENT_LINK_HEADER);
+    return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+  }
+  return response;
 });

--- a/src/pages/api/catalog.json.ts
+++ b/src/pages/api/catalog.json.ts
@@ -1,0 +1,13 @@
+import { getCollection } from "astro:content";
+import { buildAgentCatalog } from "../../lib/agent-content.ts";
+
+export const prerender = true;
+
+export async function GET() {
+  const entries = await getCollection("clinicas");
+  const catalog = buildAgentCatalog(entries);
+  return new Response(JSON.stringify(catalog), {
+    status: 200,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}

--- a/src/pages/api/openapi.json.ts
+++ b/src/pages/api/openapi.json.ts
@@ -1,0 +1,39 @@
+import { SITE_ORIGIN } from "../../lib/seo.ts";
+import { agentCatalogOpenApiSchema } from "../../lib/agent-content.ts";
+
+export const prerender = true;
+
+export async function GET() {
+  const document = {
+    openapi: "3.1.0",
+    info: {
+      title: "Vet24-cr public catalog",
+      version: "1.0.0",
+      description: "Lectura del catálogo público de clínicas veterinarias de Costa Rica.",
+    },
+    servers: [{ url: SITE_ORIGIN }],
+    paths: {
+      "/api/catalog.json": {
+        get: {
+          operationId: "getCatalog",
+          summary: "Descargar el catálogo completo",
+          responses: {
+            "200": {
+              description: "Catálogo público completo",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/Catalog" } } },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Catalog: agentCatalogOpenApiSchema,
+      },
+    },
+  };
+  return new Response(JSON.stringify(document), {
+    status: 200,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,36 @@
+import { getCollection } from "astro:content";
+import { buildAgentCatalog } from "../lib/agent-content.ts";
+import { SITE_ORIGIN } from "../lib/seo.ts";
+
+export const prerender = true;
+
+export async function GET() {
+  const entries = await getCollection("clinicas");
+  const catalog = buildAgentCatalog(entries);
+  const clinicLinks = catalog.clinics.map((clinic) => `- [${clinic.nombre ?? clinic.slug}](${clinic.url})`).join("\n");
+  const body = `# Vet24-cr
+
+Directorio público de clínicas veterinarias en Costa Rica. El catálogo contiene los registros publicados por Vet24-cr y conserva sus límites de verificación; no informa disponibilidad en tiempo real.
+
+## Recursos para agentes
+
+- Catálogo JSON: ${SITE_ORIGIN}/api/catalog.json
+- OpenAPI: ${SITE_ORIGIN}/api/openapi.json
+- Diccionario y ejemplos: ${SITE_ORIGIN}/api/readme.md
+- Acceso: ${SITE_ORIGIN}/auth.md
+- API Catalog: ${SITE_ORIGIN}/.well-known/api-catalog
+
+## Páginas HTML reales
+
+- Inicio: ${SITE_ORIGIN}/
+- Directorio por provincia: ${SITE_ORIGIN}/provincia/heredia/
+- Directorio por zona: ${SITE_ORIGIN}/zona/guapiles/
+${clinicLinks}
+
+Confirma por teléfono el horario y la atención antes de trasladarte. Filtra el catálogo descargado en tu cliente; no hay filtros ni paginación HTTP.
+`;
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}

--- a/tests/e2e/agent-discovery.spec.ts
+++ b/tests/e2e/agent-discovery.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '../../playwright.config';
+
+const RESOURCES = [
+  ['/api/catalog.json', 'application/json'],
+  ['/api/openapi.json', 'application/json'],
+  ['/llms.txt', 'text/plain'],
+  ['/api/readme.md', 'text/markdown'],
+  ['/auth.md', 'text/markdown'],
+  ['/.well-known/api-catalog', 'application/linkset+json'],
+] as const;
+
+test.describe('AR2 — descubrimiento y catálogo público', () => {
+  test('GET y HEAD entregan los seis recursos técnicos sin barra final', async ({ request }) => {
+    for (const [path, mime] of RESOURCES) {
+      const get = await request.get(path);
+      expect(get.status(), path).toBe(200);
+      expect(get.headers()['content-type'], path).toContain(mime);
+      expect(new URL(get.url()).pathname, path).toBe(path);
+
+      const head = await request.head(path);
+      expect(head.status(), `HEAD ${path}`).toBe(200);
+      expect(head.headers()['content-type'], `HEAD ${path}`).toContain(mime);
+      expect(await head.body(), `HEAD ${path}`).toHaveLength(0);
+    }
+  });
+
+  test('el catálogo y el API Catalog describen recursos reales', async ({ request }) => {
+    const catalogResponse = await request.get('/api/catalog.json');
+    const catalog = await catalogResponse.json();
+    expect(catalog.schemaVersion).toBe('1');
+    expect(catalog.timeZone).toBe('America/Costa_Rica');
+    expect(catalog.clinics.length).toBeGreaterThan(0);
+    expect(catalog.clinics.every((clinic: { openNow: null }) => clinic.openNow === null)).toBe(true);
+
+    const linkset = await (await request.get('/.well-known/api-catalog')).json();
+    expect(linkset.anchor).toBe('https://vet24cr.com/api/catalog.json');
+    expect(linkset['service-desc']).toEqual([{ href: 'https://vet24cr.com/api/openapi.json' }]);
+    expect(linkset['service-doc']).toEqual([{ href: 'https://vet24cr.com/api/readme.md' }]);
+  });
+
+  test('OpenAPI solo expone el GET público del catálogo', async ({ request }) => {
+    const openapi = await (await request.get('/api/openapi.json')).json();
+    expect(openapi.openapi).toBe('3.1.0');
+    expect(Object.keys(openapi.paths)).toEqual(['/api/catalog.json']);
+    expect(openapi.paths['/api/catalog.json'].get).toBeTruthy();
+    expect(openapi.paths['/api/catalog.json'].post).toBeUndefined();
+    expect(openapi.paths['/api/catalog.json'].get.parameters).toBeUndefined();
+    expect(openapi.paths['/api/catalog.json'].get.security).toBeUndefined();
+  });
+
+  test('portada y ficha exponen las cuatro relaciones Link', async ({ request }) => {
+    const expected = [
+      '</.well-known/api-catalog>; rel="api-catalog"',
+      '</api/openapi.json>; rel="service-desc"',
+      '</api/readme.md>; rel="service-doc"',
+      '</llms.txt>; rel="describedby"',
+    ];
+    for (const path of ['/', '/clinica/hems-una-heredia/']) {
+      const response = await request.get(path);
+      expect(response.status(), path).toBe(200);
+      const link = response.headers().link ?? '';
+      for (const relation of expected) expect(link, `${path} ${relation}`).toContain(relation);
+      for (const target of ['/.well-known/api-catalog', '/api/openapi.json', '/api/readme.md', '/llms.txt']) {
+        expect((await request.get(target)).status(), target).toBe(200);
+      }
+    }
+  });
+
+  test('el alias de sitemap redirige al índice generado', async ({ request }) => {
+    const redirect = await request.get('/sitemap.xml', { maxRedirects: 0 });
+    expect(redirect.status()).toBe(301);
+    expect(redirect.headers().location).toMatch(/sitemap-index\.xml/);
+    expect((await request.get('/sitemap-index.xml')).status()).toBe(200);
+  });
+});

--- a/tests/unit/agent-catalog.test.ts
+++ b/tests/unit/agent-catalog.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import {
+  AGENT_TIME_ZONE,
+  AGENT_WARNINGS,
+  buildAgentCatalog,
+  toAgentClinic,
+} from "../../src/lib/agent-content.ts";
+
+const fixture = {
+  id: "synthetic-false",
+  nombre: "Clínica sintética",
+  provincia: "Heredia",
+  zona: "San Pablo de Heredia",
+  direccion: "Dirección registrada",
+  telefono1: "",
+  telefono2: "2222-2222",
+  whatsapp: "",
+  horarioTexto: "Horario por confirmar",
+  categoriaHorario: "Horario normal",
+  emergencias24h: false,
+  atiendeExoticos: true,
+  cirugiaEmergencia: false,
+  atiendeGranja: false,
+  atiendePeces: false,
+  hotelMascotas: true,
+  hotelVerificacion: "no-confirmado",
+  hotelFuente: "",
+  confidence_score: "medium",
+  record_status: "PARTIAL",
+  emergency_tier: "Tier C",
+  last_verified: "",
+  phone_verified: false,
+  address_verified: false,
+  schedule_verified: false,
+  emergency_verified: false,
+  has_surgery: false,
+  has_hospitalization: true,
+  overnight_doctor_present: false,
+  accepts_emergency_walkins: false,
+  verification_notes: ["Restricción de especie registrada: solo perros y gatos."],
+  verification_source: "",
+  latitude: 0,
+  longitude: 0,
+  waze_url: "",
+  maps_url: "",
+  web: "",
+  facebook: "",
+  instagram: "",
+  slug: "clinica-sintetica",
+  estado: "pendiente",
+  copyDiferenciador: "Texto diferenciador íntegro.",
+};
+
+test("proyecta límites conservadores y conserva texto/metadata", () => {
+  const clinic = toAgentClinic({ data: fixture, body: "Cuerpo Markdown íntegro." });
+
+  assert.equal(clinic.openNow, null);
+  assert.equal(clinic.latitude, null);
+  assert.equal(clinic.longitude, null);
+  assert.equal(clinic.telefono1, null);
+  assert.equal(clinic.last_verified, null);
+  assert.equal(clinic.verification_source, null);
+  assert.equal(clinic.capacidades.emergencias24h.valorRegistrado, false);
+  assert.equal(clinic.capacidades.emergencias24h.estado, "no-confirmado");
+  assert.equal(clinic.capacidades.atiendeExoticos.estado, "afirmado");
+  assert.equal(clinic.capacidades.hotelMascotas.estado, "afirmado");
+  assert.equal(clinic.capacidades.hotelMascotas.valorRegistrado, true);
+  assert.equal(clinic.copyDiferenciador, fixture.copyDiferenciador);
+  assert.equal(clinic.bodyMarkdown, "Cuerpo Markdown íntegro.");
+  assert.deepEqual(clinic.verification_notes, fixture.verification_notes);
+  assert.deepEqual(clinic.advertencias, AGENT_WARNINGS);
+  assert.equal(AGENT_TIME_ZONE, "America/Costa_Rica");
+});
+
+test("mantiene la restricción real del hotel exclusivo para gatos", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../src/content/clinicas/hospital-vet-medical-care-heredia.md"), "utf8");
+  assert.match(source, /hotel exclusivamente para gatos con reserva previa/);
+  assert.match(source, /Hotel exclusivo para gatos, requiere reserva previa/);
+
+  const clinic = toAgentClinic({
+    data: {
+      ...fixture,
+      slug: "hospital-vet-medical-care-heredia",
+      hotelMascotas: true,
+      hotelVerificacion: "confirmado",
+      hotelFuente: "Confirmación directa; hotel exclusivo para gatos, requiere reserva previa",
+      copyDiferenciador: source.match(/copyDiferenciador: "([^"]+)/)?.[1] ?? fixture.copyDiferenciador,
+    },
+    body: source.split("---").slice(2).join("---").trim(),
+  });
+  assert.match(clinic.bodyMarkdown, /hotel exclusivamente para gatos con reserva previa/);
+  assert.match(clinic.hotelFuente ?? "", /exclusivo para gatos, requiere reserva previa/);
+  assert.equal(clinic.capacidades.hotelMascotas.valorRegistrado, true);
+});
+
+test("ordena el catálogo por slug sin filtrar estado", () => {
+  const catalog = buildAgentCatalog([
+    { data: { ...fixture, slug: "zeta", estado: "inactivo" } },
+    { data: { ...fixture, slug: "alfa", estado: "publicado" } },
+  ]);
+  assert.deepEqual(catalog.clinics.map((clinic) => clinic.slug), ["alfa", "zeta"]);
+  assert.equal(catalog.clinics.length, 2);
+});

--- a/tests/unit/agent-discovery.test.ts
+++ b/tests/unit/agent-discovery.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AGENT_LINK_HEADER, isAgentDiscoverableHtmlPath } from "../../src/lib/agent-discovery.ts";
+
+test("expone las cuatro relaciones exactas en HTML de descubrimiento", () => {
+  assert.equal(
+    AGENT_LINK_HEADER,
+    '</.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"',
+  );
+  for (const path of ["/", "/clinica/hems-una-heredia/", "/provincia/heredia/", "/zona/guapiles/"]) {
+    assert.equal(isAgentDiscoverableHtmlPath(path), true);
+  }
+  for (const path of ["/api/catalog.json", "/auth.md", "/.well-known/api-catalog", "/acerca/"]) {
+    assert.equal(isAgentDiscoverableHtmlPath(path), false);
+  }
+});


### PR DESCRIPTION
Implementa AR2 — Catálogo público y descubrimiento, sobre main con AR1 fusionada (06cab06).

Incluye:
- adaptador conservador desde la colección clinicas, sin filtro de estado, openNow: null, coordenadas/flags/advertencias y texto íntegro;
- /api/catalog.json, /api/openapi.json, /llms.txt, /api/readme.md, /auth.md y /.well-known/api-catalog;
- cabeceras Link para portada/fichas/provincias/zonas, CORS/MIME acotados y alias /sitemap.xml;
- pruebas unitarias/E2E y scripts/verification/agent-catalog.mjs.

Verificación de implementación:
- npm ci: 0
- npm run build:no-shorten: 0
- validador AR2: 0 (112 clínicas y 112 rutas HTML)
- npm run types:worker: 0; worker-configuration.d.ts sin cambios
- npm run check: 0 errores
- npm test: 41/41
- npm run deploy:dry-run: 0
- E2E AR2: 5/5; E2E completa serial: 77 pasadas y 11 skips históricos
- La corrida paralela local con 8 workers produjo timeouts por saturación del preview; quedó documentada como no funcional en docs/agent-readiness/evidencia/ar2/verification-common.json.

La evidencia está en docs/agent-readiness/evidencia/ar2/.
La sesión implementadora no fusiona ni despliega: la verificación CI/HTTP/productiva y la fusión corresponden a otra sesión.