### PR TITLE
fix(ar2): publish API Catalog as a linkset

### DIFF
--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,9 +1,13 @@
 {
-  "anchor": "https://vet24cr.com/api/catalog.json",
-  "service-desc": [
-    { "href": "https://vet24cr.com/api/openapi.json" }
-  ],
-  "service-doc": [
-    { "href": "https://vet24cr.com/api/readme.md" }
+  "linkset": [
+    {
+      "anchor": "https://vet24cr.com/api/catalog.json",
+      "service-desc": [
+        { "href": "https://vet24cr.com/api/openapi.json" }
+      ],
+      "service-doc": [
+        { "href": "https://vet24cr.com/api/readme.md" }
+      ]
+    }
   ]
 }

--- a/scripts/verification/agent-catalog.mjs
+++ b/scripts/verification/agent-catalog.mjs
@@ -74,12 +74,15 @@ if (openapi) {
 }
 
 if (linkset) {
-  if (linkset.anchor !== "https://vet24cr.com/api/catalog.json") errors.push("API Catalog anchor mismatch");
-  const desc = linkset["service-desc"]?.map((item) => item.href) ?? [];
-  const docs = linkset["service-doc"]?.map((item) => item.href) ?? [];
+  if (!Array.isArray(linkset.linkset) || linkset.linkset.length !== 1) errors.push("API Catalog linkset must contain exactly one entry");
+  const entry = linkset.linkset?.[0] ?? {};
+  if (entry.anchor !== "https://vet24cr.com/api/catalog.json") errors.push("API Catalog anchor mismatch");
+  const desc = entry["service-desc"]?.map((item) => item.href) ?? [];
+  const docs = entry["service-doc"]?.map((item) => item.href) ?? [];
   if (desc.length !== 1 || desc[0] !== "https://vet24cr.com/api/openapi.json") errors.push("API Catalog service-desc mismatch");
   if (docs.length !== 1 || docs[0] !== "https://vet24cr.com/api/readme.md") errors.push("API Catalog service-doc mismatch");
-  if (Object.keys(linkset).some((key) => !["anchor", "service-desc", "service-doc"].includes(key))) errors.push("API Catalog contains unexpected relation");
+  if (Object.keys(linkset).some((key) => key !== "linkset")) errors.push("API Catalog contains unexpected top-level member");
+  if (Object.keys(entry).some((key) => !["anchor", "service-desc", "service-doc"].includes(key))) errors.push("API Catalog contains unexpected relation");
 }
 
 if (llmsText && (!llmsText.startsWith("# Vet24-cr") || !llmsText.includes("/api/catalog.json") || !llmsText.includes("/api/readme.md"))) errors.push("llms.txt is missing required discovery links");

--- a/tests/e2e/agent-discovery.spec.ts
+++ b/tests/e2e/agent-discovery.spec.ts
@@ -33,9 +33,10 @@ test.describe('AR2 — descubrimiento y catálogo público', () => {
     expect(catalog.clinics.every((clinic: { openNow: null }) => clinic.openNow === null)).toBe(true);
 
     const linkset = await (await request.get('/.well-known/api-catalog')).json();
-    expect(linkset.anchor).toBe('https://vet24cr.com/api/catalog.json');
-    expect(linkset['service-desc']).toEqual([{ href: 'https://vet24cr.com/api/openapi.json' }]);
-    expect(linkset['service-doc']).toEqual([{ href: 'https://vet24cr.com/api/readme.md' }]);
+    expect(linkset.linkset).toHaveLength(1);
+    expect(linkset.linkset[0].anchor).toBe('https://vet24cr.com/api/catalog.json');
+    expect(linkset.linkset[0]['service-desc']).toEqual([{ href: 'https://vet24cr.com/api/openapi.json' }]);
+    expect(linkset.linkset[0]['service-doc']).toEqual([{ href: 'https://vet24cr.com/api/readme.md' }]);
   });
 
   test('OpenAPI solo expone el GET público del catálogo', async ({ request }) => {


### PR DESCRIPTION
## Summary\n\nProduction currently returns HTTP 200 with the expected pplication/linkset+json MIME for /.well-known/api-catalog, but the live isitagentready.com scan reports piCatalog=fail because the JSON is missing the top-level linkset array required by the published RFC 9727 guide.\n\nThis PR:\n- wraps the single API entry in the required linkset array;\n- updates the local artifact validator;\n- updates the AR2 E2E assertions.\n\nValidation: 
pm run build:no-shorten, 
ode scripts/verification/agent-catalog.mjs, 
pm test, and 
pm run check pass. The targeted Playwright E2E could not start its preview server in the verification environment.\n\nThe repository spec currently describes the direct object shape, so this PR intentionally leaves that spec unchanged and calls out the contract discrepancy for owner review. After merge and automatic deployment, rerun the production curls and complete scan before considering issue #13 verified. This PR does not close issue #13.