### PR TITLE
docs(ar3): archivar evidencia de verificación post-despliegue

### DIFF
--- a/docs/agent-readiness/evidencia/ar3/api-report-incorrect.md
+++ b/docs/agent-readiness/evidencia/ar3/api-report-incorrect.md
@@ -1,0 +1,16 @@
+# AR3 — conservación de `/api/report-incorrect/`
+
+Fecha: 2026-09-06. Probe ejecutado contra producción:
+
+```text
+curl.exe -sS -D - -o NUL -X POST https://vet24cr.com/api/report-incorrect/ -H "Content-Type: application/json" --data '{"slug":"__ar3_probe__","reason":"verification"}'
+```
+
+Resultado observado: `HTTP/1.1 200 OK`, `Content-Type: application/json`,
+`Content-Length: 114`. La ruta sigue siendo atendida por su endpoint previo;
+el nuevo routing solo incluye las familias HTML contractuales y no consume
+este POST.
+
+El cuerpo se descartó deliberadamente con `-o NUL`, por lo que no se presenta
+un cuerpo inventado como evidencia.
+

--- a/docs/agent-readiness/evidencia/ar3/ar3-06-auditoria-ia.md
+++ b/docs/agent-readiness/evidencia/ar3/ar3-06-auditoria-ia.md
@@ -1,0 +1,27 @@
+# AR3-06 — auditoría con tres IAs
+
+Estado: **pendiente por falta de acceso a tres infraestructuras de búsqueda
+distintas**. No se fabrican conversaciones, modelos, respuestas, rutas
+recuperadas ni citas.
+
+La sesión actual puede verificar HTTP directamente y archivó esa evidencia en
+[production-verification.md](production-verification.md), pero no tiene tres
+conversaciones nuevas independientes en infraestructuras de IA distintas.
+Por tanto AR3-06 no se declara cumplido.
+
+## Consultas literales de la spec
+
+Cada infraestructura debe recibir ambas consultas en una conversación nueva,
+sin contexto previo:
+
+1. `Usando https://vet24cr.com, ¿qué clínica está abierta ahora cerca de San Pablo de Heredia? Indica qué podés confirmar, horario registrado, teléfono, URL de ficha y límites de actualidad.`
+2. `Usando https://vet24cr.com, ¿qué opciones de emergencias hay en Heredia? Distingue lo reportado como 24/7 de disponibilidad confirmada y conservá restricciones relevantes.`
+
+## Evidencia que falta
+
+Para cada una de las tres IAs se deben conservar íntegramente las dos
+respuestas, nombre/modelo/herramienta, fecha, rutas de Vet24 recuperadas y la
+comparación HTTP de cada hallazgo. Cada discrepancia debe clasificarse como
+fallo del sitio, limitación de la herramienta o deuda de datos conocida (por
+ejemplo, HEMS sin fecha/fuente o Medical Care con hotel limitado a gatos).
+

--- a/docs/agent-readiness/evidencia/ar3/production-headers.txt
+++ b/docs/agent-readiness/evidencia/ar3/production-headers.txt
@@ -1,0 +1,144 @@
+AR3 production HTTP verification — 2026-09-06
+Command 1
+
+1) GET markdown
+HTTP/1.1 200 OK
+Date: Sun, 06 Sep 2026 16:46:49 GMT
+Content-Type: text/markdown; charset=utf-8
+Content-Length: 2646
+Connection: keep-alive
+CF-Cache-Status: HIT
+Cache-Control: private, no-store
+ETag: "2ea20e4f58f078cd87ee8811a6063bed"
+Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"
+Vary: Accept
+access-control-allow-methods: GET, HEAD
+Report-To: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=Ey2QddSfZ4%2F48jT6%2F0qcHHaVuuCAePk6%2FUETNPzWmnav2FOj9p41ZQDAvA%2ByLjdmYXHDkqS%2BacViVLCcQY%2BkaGGQtacXWoNsMBhS01vQqgP0RDtEZ8Y2LRCgXEcskg%3D%3D"}]}
+Nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+Server: cloudflare
+CF-RAY: a36ef3b5985fc846-SJO
+alt-svc: h3=":443"; ma=86400
+
+2) GET default
+HTTP/1.1 200 OK
+Date: Sun, 06 Sep 2026 16:46:49 GMT
+Content-Type: text/html
+Transfer-Encoding: chunked
+Connection: keep-alive
+CF-Cache-Status: HIT
+Cache-Control: private, no-store
+Nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"
+Vary: Accept
+access-control-allow-methods: GET, HEAD
+Report-To: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=jTSNC4yEU4Kea6KA3mgnm%2FZFdz0ebpWjfNbOca3am6NLKcyKT0OinFvsUedBVYlkmHPr%2FpkgPvq%2FZqDUkUA0vWDB8uaNUTUh0%2FBIYl7i1cY45RMTrv%2BHzOdZpJ7rPA%3D%3D"}]}
+Server: cloudflare
+CF-RAY: a36ef3b64ebb7139-SJO
+alt-svc: h3=":443"; ma=86400
+
+3) GET q=0
+HTTP/1.1 200 OK
+Date: Sun, 06 Sep 2026 16:46:49 GMT
+Content-Type: text/html
+Transfer-Encoding: chunked
+Connection: keep-alive
+CF-Cache-Status: HIT
+Cache-Control: private, no-store
+Nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"
+Vary: Accept
+access-control-allow-methods: GET, HEAD
+Report-To: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=Y4OmEyWZEVuKJ7Otar2tsZcy3NFyHtKIK8QAlPPdIYDLrpIyj%2F4bg4YpYIRTzT2wlwictSOC%2FQnqZYcN%2Ff%2BuWe2MvrhduhtygvlJGutu12sIm%2F%2FLDRWtZmqlEXhZAA%3D%3D"}]}
+Server: cloudflare
+CF-RAY: a36ef3b70da9c264-SJO
+alt-svc: h3=":443"; ma=86400
+
+4) HEAD markdown
+HTTP/1.1 200 OK
+Date: Sun, 06 Sep 2026 16:46:49 GMT
+Content-Type: text/markdown; charset=utf-8
+Connection: keep-alive
+CF-Cache-Status: HIT
+Cache-Control: private, no-store
+ETag: "2ea20e4f58f078cd87ee8811a6063bed"
+Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"
+Vary: Accept
+access-control-allow-methods: GET, HEAD
+Report-To: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=kyvkMRu3Z5uNIZQNJ%2FXOnosK6oGSFxKqSinln0QCgUY2x1XmWqj2dG1ZbHyCew04kBcocdU0y7sgEiBuEJhWUyTB%2Bp6jZqaYMWN%2FgnsGCt1dLnPeqh%2F8teBjgjDxsA%3D%3D"}]}
+Nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+Server: cloudflare
+CF-RAY: a36ef3b90bbe7139-SJO
+alt-svc: h3=":443"; ma=86400
+
+5) direct mirror
+HTTP/1.1 200 OK
+Date: Sun, 06 Sep 2026 16:46:49 GMT
+Content-Type: text/markdown; charset=utf-8
+Content-Length: 2646
+Connection: keep-alive
+CF-Cache-Status: HIT
+Access-Control-Allow-Origin: *
+Cache-Control: public, max-age=0, must-revalidate
+ETag: "2ea20e4f58f078cd87ee8811a6063bed"
+access-control-allow-methods: GET, HEAD
+x-robots-tag: noindex
+Report-To: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=3Xpofnld5acf279aJBjveSibk0hL9pbZA%2B0i8EB7lXi%2Fs0to76njNgrSISplMXXmj%2By4g5QCorkaqX7oMv67aZ84AxxHzM%2FVyBfngXZhYMuuH%2BjErGwU50z503ZOnA%3D%3D"}]}
+Nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+Server: cloudflare
+CF-RAY: a36ef3b9f898567d-SJO
+alt-svc: h3=":443"; ma=86400
+
+6) province markdown
+HTTP/1.1 200 OK
+Date: Sun, 06 Sep 2026 16:46:50 GMT
+Content-Type: text/markdown; charset=utf-8
+Content-Length: 9462
+Connection: keep-alive
+CF-Cache-Status: HIT
+Cache-Control: private, no-store
+ETag: "e83f30154c5aaca9e40d7fe4d5d7d62e"
+Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"
+Vary: Accept
+access-control-allow-methods: GET, HEAD
+Report-To: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=TnnmZZeFQcfiDFyxW96hLUzyCMh2HTpn8Tm%2FAgdbvqVdXhctIKUf4UoLZ1EZCbuX%2FuLk4WuEFmWxoy638nkmdjpCABY67RGu3pHh7yq445qAUGmtQlIsEw%2BrsW703A%3D%3D"}]}
+Nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+Server: cloudflare
+CF-RAY: a36ef3babeaec846-SJO
+alt-svc: h3=":443"; ma=86400
+
+7) root markdown
+HTTP/1.1 200 OK
+Date: Sun, 06 Sep 2026 16:46:50 GMT
+Content-Type: text/markdown; charset=utf-8
+Content-Length: 86049
+Connection: keep-alive
+CF-Cache-Status: HIT
+Cache-Control: private, no-store
+ETag: "57a3a3801f3dab268226c31f4c498739"
+Link: </.well-known/api-catalog>; rel="api-catalog", </api/openapi.json>; rel="service-desc", </api/readme.md>; rel="service-doc", </llms.txt>; rel="describedby"
+Vary: Accept
+access-control-allow-methods: GET, HEAD
+Report-To: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=mj4u%2BwZqC8BtRHWcMhfrz9ekc3zTGkAsr0EFbfZgbOGeDt1JTt43APPpNPRQir8CNAomaGaEWLxvgy1%2FO%2BkyUICeLHUYaXCjlC02woxAXezSLpIlmJl1NX41Fz4uYw%3D%3D"}]}
+Nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+Server: cloudflare
+CF-RAY: a36ef3bb6bc78777-SJO
+alt-svc: h3=":443"; ma=86400
+
+8) root direct mirror
+HTTP/1.1 200 OK
+Date: Sun, 06 Sep 2026 16:46:50 GMT
+Content-Type: text/markdown; charset=utf-8
+Content-Length: 86049
+Connection: keep-alive
+CF-Cache-Status: HIT
+Access-Control-Allow-Origin: *
+Cache-Control: public, max-age=0, must-revalidate
+ETag: "57a3a3801f3dab268226c31f4c498739"
+access-control-allow-methods: GET, HEAD
+x-robots-tag: noindex
+Report-To: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=WeCE5HxKyl1FOM4lAJ6l%2BfwqfvmaHb2OqlWNqLeRoRjOm7yvIGi8S0K4Yd5H9MNyfgkGNuBKyDTD%2BpFFIcLm1taX2pZHDe8abqZKr1xfzM2hSlsl6UC%2B3eiCvc7mCw%3D%3D"}]}
+Nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+Server: cloudflare
+CF-RAY: a36ef3bc28c07139-SJO
+alt-svc: h3=":443"; ma=86400
+

--- a/docs/agent-readiness/evidencia/ar3/production-verification.md
+++ b/docs/agent-readiness/evidencia/ar3/production-verification.md
@@ -1,0 +1,43 @@
+# AR3 — verificación productiva
+
+Fecha de la sesión: 2026-09-06
+Sitio: `https://vet24cr.com`
+Rama de evidencia: `ar3/markdown-validation`
+
+## AR3-02/03/04
+
+La batería exacta solicitada en el issue se ejecutó contra producción. Las
+cabeceras completas están en [production-headers.txt](production-headers.txt).
+
+- Ficha HEMS con `Accept: text/markdown`: `200`, `text/markdown; charset=utf-8`, `Vary: Accept` y `Cache-Control: private, no-store`.
+- Ficha HEMS sin `Accept` y con `Accept: text/markdown;q=0`: `200`, `text/html`, conservando `Vary: Accept` y `Cache-Control: private, no-store`.
+- `HEAD` de la ficha con `Accept: text/markdown`: `200`, `text/markdown`, con las mismas cabeceras de selección y sin cuerpo.
+- Mirror directo de HEMS: `200`, `text/markdown`, `Access-Control-Allow-Origin: *` y `x-robots-tag: noindex`.
+- Listado de Heredia y portada negociados: `200`, `text/markdown`, `Vary: Accept` y `Cache-Control: private, no-store`.
+- Mirror directo de portada: `200`, `text/markdown`, CORS público y `x-robots-tag: noindex`.
+- La respuesta HTML de HEMS contiene canonical y no contiene `noindex`; la respuesta Markdown empieza con heading y no es HTML.
+- La configuración desplegada conserva `run_worker_first` limitado a `/`, `/clinica/*`, `/provincia/*` y `/zona/*`; no captura `/api/` completo.
+
+El POST de `/api/report-incorrect/` se probó con un payload de verificación y
+respondió `200 application/json`; no se modificó el endpoint ni se añadió una
+captura de su ruta al worker de Markdown. El detalle del probe está en
+[api-report-incorrect.md](api-report-incorrect.md).
+
+## AR3-05
+
+El escaneo completo está archivado en
+[scan-post-deploy.json](scan-post-deploy.json), con `scannedAt`
+`2026-09-06T16:45:09.890Z`.
+
+Los seis checks funcionales heredados de AR2 permanecen en `pass`:
+`robotsTxt`, `sitemap`, `linkHeaders`, `robotsTxtAiRules`, `contentSignals` y
+`apiCatalog`. Se suma `markdownNegotiation=pass`.
+
+El script produjo el JSON completo, pero Node `v24.11.1` terminó con una
+aserción de libuv al cerrar (`UV_HANDLE_CLOSING`) después de escribir la
+respuesta JSON. El archivo es JSON válido y conserva la respuesta completa del
+escáner; no se oculta ese límite de ejecución.
+
+Como comprobación local complementaria, `npm ci` terminó con 335 paquetes y
+0 vulnerabilidades, `npm test` pasó `50/50`, `npm run build:no-shorten`
+completó y `node scripts/verification/agent-markdown.mjs` pasó `127 mirrors`.

--- a/docs/agent-readiness/evidencia/ar3/scan-comparison.md
+++ b/docs/agent-readiness/evidencia/ar3/scan-comparison.md
@@ -1,0 +1,31 @@
+# AR3 — comparativa del escaneo
+
+La comparación usa [scan-pre-deploy.json](scan-pre-deploy.json) y
+[scan-post-deploy.json](scan-post-deploy.json). El único cambio de estado
+entre ambos escaneos es:
+
+```text
+markdownNegotiation: fail -> pass
+```
+
+## Checks no pasados o informativos
+
+Estos resultados no son regresiones introducidas por AR3:
+
+- `dnsAid=fail`: decisión de DNS-AID no autorizada en esta fase; no se publica
+  ningún endpoint ni registro adicional.
+- `authMd=fail`: limitación aceptada de AR2/D7; el sitio no ofrece registro de
+  agentes ni OAuth ficticio.
+- `oauthDiscovery=fail` y `oauthProtectedResource=fail`: fuera de alcance.
+- `mcpServerCard=fail`, `a2aAgentCard=fail`, `agentSkills=fail`, `webMcp=fail` y
+  `ard=fail`: capas de descubrimiento/protocolo fuera de alcance; no se
+  inventan endpoints.
+- `webBotAuth=neutral`: no es un criterio funcional fallido; el directorio es
+  informativo.
+- `x402=neutral`, `mpp=neutral`, `ucp=neutral`, `acp=neutral` y `ap2=neutral`:
+  protocolos comerciales no aplicables al directorio.
+
+Las capas superiores 4/5 y DNS-AID quedan expresamente como decisiones no
+autorizadas. El escaneo se conserva íntegro para que esas decisiones no se
+confundan con una certificación.
+

--- a/docs/agent-readiness/evidencia/ar3/scan-post-deploy.json
+++ b/docs/agent-readiness/evidencia/ar3/scan-post-deploy.json
@@ -1,0 +1,1398 @@
+{
+  "url": "https://vet24cr.com",
+  "targetUrl": "https://vet24cr.com",
+  "scannedAt": "2026-09-06T16:45:09.890Z",
+  "level": 4,
+  "levelName": "Agent-Integrated",
+  "checks": {
+    "discoverability": {
+      "robotsTxt": {
+        "status": "pass",
+        "message": "robots.txt exists with valid format",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /robots.txt",
+            "request": {
+              "url": "https://vet24cr.com/robots.txt",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/plain",
+                "content-length": "125",
+                "cf-ray": "a36ef12498197df0-SJO"
+              },
+              "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received valid robots.txt (200, text/plain)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Validate robots.txt structure",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Contains valid User-agent directive(s)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "robots.txt exists with valid format"
+            }
+          }
+        ],
+        "durationMs": 0
+      },
+      "sitemap": {
+        "status": "pass",
+        "message": "sitemap.xml exists with valid structure",
+        "details": {
+          "url": "https://vet24cr.com/sitemap-index.xml",
+          "fromRobotsTxt": true,
+          "format": "xml"
+        },
+        "evidence": [
+          {
+            "action": "parse",
+            "label": "Extract Sitemap directives from robots.txt",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found 1 Sitemap directive(s) in robots.txt"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /sitemap-index.xml",
+            "request": {
+              "url": "https://vet24cr.com/sitemap-index.xml",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/xml",
+                "content-length": "182",
+                "cf-ray": "a36ef124d8337df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found valid xml sitemap at https://vet24cr.com/sitemap-index.xml"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "sitemap.xml exists with valid structure"
+            }
+          }
+        ],
+        "durationMs": 9
+      },
+      "linkHeaders": {
+        "status": "pass",
+        "message": "Found agent-useful Link relations: api-catalog, service-desc, service-doc, describedby",
+        "details": {
+          "relationsFound": [
+            {
+              "rel": "api-catalog",
+              "href": "/.well-known/api-catalog"
+            },
+            {
+              "rel": "service-desc",
+              "href": "/api/openapi.json"
+            },
+            {
+              "rel": "service-doc",
+              "href": "/api/readme.md"
+            },
+            {
+              "rel": "describedby",
+              "href": "/llms.txt"
+            }
+          ],
+          "totalLinks": 4
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "link": "</.well-known/api-catalog>; rel=\"api-catalog\", </api/openapi.json>; rel=\"service-desc\", </api/readme.md>; rel=\"service-doc\", </llms.txt>; rel=\"describedby\"",
+                "cf-ray": "a36ef125286b7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Target page returned 200 with Link header"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Parse Link header (RFC 8288)",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Parsed 4 link(s) from header"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Match agent-useful relations",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found agent-useful relations: api-catalog, service-desc, service-doc, describedby"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found agent-useful Link relations: api-catalog, service-desc, service-doc, describedby"
+            }
+          }
+        ],
+        "durationMs": 71
+      },
+      "dnsAid": {
+        "status": "fail",
+        "message": "DNS for AI Discovery (DNS-AID) well-known entrypoint records not found",
+        "details": {
+          "domainsChecked": [
+            "vet24cr.com"
+          ],
+          "queriesAttempted": [
+            "SVCB _index._agents.vet24cr.com",
+            "HTTPS _index._agents.vet24cr.com",
+            "SVCB _a2a._agents.vet24cr.com",
+            "HTTPS _a2a._agents.vet24cr.com",
+            "SVCB _mcp._agents.vet24cr.com",
+            "HTTPS _mcp._agents.vet24cr.com",
+            "TXT _index._agents.vet24cr.com"
+          ],
+          "dnssecValidated": false,
+          "serviceRecordCount": 0,
+          "aliasRecordCount": 0,
+          "txtIndexEntryCount": 0,
+          "txtIndexEntries": [],
+          "records": []
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "DoH SVCB _index._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_index._agents.vet24cr.com&type=SVCB&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SVCB answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH HTTPS _index._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_index._agents.vet24cr.com&type=HTTPS&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No HTTPS answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH SVCB _a2a._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_a2a._agents.vet24cr.com&type=SVCB&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SVCB answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH HTTPS _a2a._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_a2a._agents.vet24cr.com&type=HTTPS&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_a2a._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No HTTPS answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH SVCB _mcp._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_mcp._agents.vet24cr.com&type=SVCB&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":64}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SVCB answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH HTTPS _mcp._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_mcp._agents.vet24cr.com&type=HTTPS&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_mcp._agents.vet24cr.com\",\"type\":65}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No HTTPS answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH TXT _index._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_index._agents.vet24cr.com&type=TXT&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_index._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No TXT answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Parse DNS for AI Discovery (DNS-AID) SVCB/HTTPS records",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No DNS for AI Discovery (DNS-AID) SVCB or HTTPS records found at well-known entrypoints"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "DNS for AI Discovery (DNS-AID) well-known entrypoint records not found"
+            }
+          }
+        ],
+        "durationMs": 5
+      }
+    },
+    "contentAccessibility": {
+      "markdownNegotiation": {
+        "status": "pass",
+        "message": "Site supports Markdown for Agents",
+        "details": {
+          "contentType": "text/markdown; charset=utf-8"
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET target page (Accept: text/markdown)",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET",
+              "headers": {
+                "accept": "text/markdown",
+                "cache-control": "no-cache"
+              }
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Response content-type is text/markdown; charset=utf-8 -- site supports markdown negotiation"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/markdown; charset=utf-8",
+                "cf-ray": "a36ef131e9c0c9df-MIA"
+              }
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Site supports Markdown for Agents"
+            }
+          }
+        ],
+        "durationMs": 540
+      }
+    },
+    "botAccessControl": {
+      "robotsTxtAiRules": {
+        "status": "pass",
+        "message": "No AI-specific bot rules; wildcard rules apply to all crawlers including AI bots",
+        "details": {
+          "checkedBots": [
+            "gptbot",
+            "chatgpt-user",
+            "google-extended",
+            "ccbot",
+            "anthropic-ai",
+            "claude-web",
+            "bytespider",
+            "perplexitybot",
+            "cohere-ai",
+            "applebot-extended",
+            "amazonbot",
+            "meta-externalagent",
+            "facebookbot",
+            "omgilibot",
+            "diffbot"
+          ]
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /robots.txt",
+            "request": {
+              "url": "https://vet24cr.com/robots.txt",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/plain",
+                "content-length": "125",
+                "cf-ray": "a36ef12498197df0-SJO"
+              },
+              "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received valid robots.txt (200, text/plain)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Scan for AI bot User-agent directives",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Checked 15 AI bot user agents -- none found, but wildcard rules apply"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "No AI-specific bot rules; wildcard rules apply to all crawlers including AI bots"
+            }
+          }
+        ],
+        "durationMs": 0
+      },
+      "contentSignals": {
+        "status": "pass",
+        "message": "Content Signals found in robots.txt",
+        "details": {
+          "signals": [
+            {
+              "userAgent": "*",
+              "path": null,
+              "aiTrain": "no",
+              "search": "yes",
+              "aiInput": "yes"
+            }
+          ],
+          "signalCount": 1
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /robots.txt",
+            "request": {
+              "url": "https://vet24cr.com/robots.txt",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/plain",
+                "content-length": "125",
+                "cf-ray": "a36ef12498197df0-SJO"
+              },
+              "bodyPreview": "User-agent: *\nAllow: /\nContent-Signal: search=yes, ai-input=yes, ai-train=no\n\nSitemap: https://vet24cr.com/sitemap-index.xml\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received valid robots.txt (200, text/plain)"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Parse Content-Signal directives",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found 1 Content-Signal directive(s)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Content Signals found in robots.txt"
+            }
+          }
+        ],
+        "durationMs": 0
+      },
+      "webBotAuth": {
+        "status": "neutral",
+        "message": "Web Bot Auth directory not found (informational only)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/http-message-signatures-directory",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/http-message-signatures-directory",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124d8317df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- Web Bot Auth directory not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "Web Bot Auth directory not found"
+            }
+          }
+        ],
+        "durationMs": 9
+      }
+    },
+    "discovery": {
+      "apiCatalog": {
+        "status": "pass",
+        "message": "API Catalog found with 1 API listed",
+        "details": {
+          "apiCount": 1,
+          "linksetEntries": 1,
+          "hasItems": false,
+          "hasNestedCatalogs": false,
+          "correctContentType": true
+        },
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/api-catalog",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/api-catalog",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/linkset+json, application/json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/linkset+json; charset=utf-8",
+                "content-length": "270",
+                "cf-ray": "a36ef125085a7df0-SJO"
+              },
+              "bodyPreview": "{\"linkset\":[{\"anchor\":\"https://vet24cr.com/api/catalog.json\",\"service-desc\":[{\"href\":\"https://vet24cr.com/api/openapi.json\"}],\"service-doc\":[{\"href\":\"https://vet24cr.com/api/readme.md\"}]}]}"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received 200 with valid JSON response"
+            }
+          },
+          {
+            "action": "validate",
+            "label": "Validate Linkset structure",
+            "finding": {
+              "outcome": "positive",
+              "summary": "Found \"linkset\" array with 1 entries"
+            }
+          },
+          {
+            "action": "validate",
+            "label": "Analyze linkset entries",
+            "finding": {
+              "outcome": "positive",
+              "summary": "1 API listed, correct content-type"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "positive",
+              "summary": "API Catalog found with 1 API listed"
+            }
+          }
+        ],
+        "durationMs": 35
+      },
+      "oauthDiscovery": {
+        "status": "fail",
+        "message": "No OAuth/OIDC discovery metadata found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/openid-configuration",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/openid-configuration",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124d8327df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "openid-configuration returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/oauth-authorization-server",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/oauth-authorization-server",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124d83a7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "oauth-authorization-server returned 404"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No OAuth/OIDC discovery metadata found at either well-known path"
+            }
+          }
+        ],
+        "durationMs": 12
+      },
+      "oauthProtectedResource": {
+        "status": "fail",
+        "message": "No OAuth Protected Resource Metadata found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/oauth-protected-resource",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/oauth-protected-resource",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124d83b7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "link": "</.well-known/api-catalog>; rel=\"api-catalog\", </api/openapi.json>; rel=\"service-desc\", </api/readme.md>; rel=\"service-doc\", </llms.txt>; rel=\"describedby\"",
+                "cf-ray": "a36ef124e83f7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Target resource returned 200 (no WWW-Authenticate header)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No OAuth Protected Resource Metadata found"
+            }
+          }
+        ],
+        "durationMs": 29
+      },
+      "authMd": {
+        "status": "fail",
+        "message": "auth.md exists but does not describe agent registration",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /auth.md",
+            "request": {
+              "url": "https://vet24cr.com/auth.md",
+              "method": "GET",
+              "headers": {
+                "Accept": "text/markdown, text/plain, */*"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/markdown; charset=utf-8",
+                "content-length": "454",
+                "cf-ray": "a36ef124e8417df0-SJO"
+              },
+              "bodyPreview": "# auth.md\n\nEl catálogo público de Vet24-cr es anónimo y de solo lectura. No requiere registro, API key, OAuth ni credenciales:\n\n- `GET https://vet24cr.com/api/catalog.json` devuelve el catálogo público.\n- No hay filtros ni paginación HTTP.\n- El endpoint no concede permisos para escribir, editar o reportar datos.\n\nLos horarios y capacidades son datos registrados con límites explícitos; confirma la atención por teléfono antes de trasladarte.\n"
+            },
+            "finding": {
+              "outcome": "positive",
+              "summary": "Received 200 response with content-type: text/markdown; charset=utf-8"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Detect Auth.md registration markers",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No Auth.md agent registration markers found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "auth.md exists but does not describe agent registration"
+            }
+          }
+        ],
+        "durationMs": 17
+      },
+      "mcpServerCard": {
+        "status": "fail",
+        "message": "MCP Server Card not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/mcp/server-card.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/mcp/server-card.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124e8427df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "/.well-known/mcp/server-card.json returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/mcp/server-cards.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/mcp/server-cards.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124e8437df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "/.well-known/mcp/server-cards.json returned 404"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/mcp.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/mcp.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124e8487df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "/.well-known/mcp.json returned 404"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "MCP Server Card not found at any candidate path"
+            }
+          }
+        ],
+        "durationMs": 33
+      },
+      "a2aAgentCard": {
+        "status": "fail",
+        "message": "A2A Agent Card not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/agent-card.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/agent-card.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124e84a7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- A2A Agent Card not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "A2A Agent Card not found"
+            }
+          }
+        ],
+        "durationMs": 31
+      },
+      "agentSkills": {
+        "status": "fail",
+        "message": "Agent Skills index not found",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/agent-skills/index.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/agent-skills/index.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124f8507df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "v0.2.0 path returned 404 — trying legacy path"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/skills/index.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/skills/index.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef125286c7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 — Agent Skills index not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "Agent Skills index not found"
+            }
+          }
+        ],
+        "durationMs": 72
+      },
+      "webMcp": {
+        "status": "fail",
+        "message": "No WebMCP tools detected on page load",
+        "evidence": [
+          {
+            "action": "parse",
+            "label": "WebMCP detection",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Checking page for WebMCP tool registrations"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "Navigate to https://vet24cr.com",
+            "request": {
+              "url": "https://vet24cr.com",
+              "method": "GET"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "Loading page to detect WebMCP tool registrations"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Check imperative WebMCP API",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No tools registered via navigator.modelContext"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No WebMCP tools detected on page load"
+            }
+          }
+        ],
+        "durationMs": 3884
+      },
+      "ard": {
+        "status": "fail",
+        "message": "ARD capability manifest not found",
+        "evidence": [
+          {
+            "action": "parse",
+            "label": "Extract Agentmap directives from robots.txt",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No Agentmap directives found"
+            }
+          },
+          {
+            "action": "parse",
+            "label": "Extract <link rel=\"ai-catalog\"> from page head",
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No catalog links found"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/ai-catalog.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/ai-catalog.json",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/json"
+              }
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef124d8357df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- ai-catalog.json not found"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH TXT _catalog._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_catalog._agents.vet24cr.com&type=TXT&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_catalog._agents.vet24cr.com\",\"type\":16}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No TXT answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "DoH SRV _search._agents.vet24cr.com",
+            "request": {
+              "url": "https://cloudflare-dns.com/dns-query?name=_search._agents.vet24cr.com&type=SRV&do=1",
+              "method": "GET",
+              "headers": {
+                "Accept": "application/dns-json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/dns-json"
+              },
+              "bodyPreview": "{\"Status\":3,\"TC\":false,\"RD\":true,\"RA\":true,\"AD\":false,\"CD\":false,\"Question\":[{\"name\":\"_search._agents.vet24cr.com\",\"type\":33}],\"Authority\":[{\"name\":\"vet24cr.com\",\"type\":6,\"TTL\":1800,\"data\":\"eric.ns.cloudflare.com. dns.cloudflare.com. 2414029628 10000 2400 604800 1800\"}]}"
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "No SRV answers (NXDOMAIN)"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "ARD capability manifest not found"
+            }
+          }
+        ],
+        "details": {
+          "discoveryMechanisms": [],
+          "searchEndpoints": []
+        },
+        "durationMs": 10
+      }
+    },
+    "commerce": {
+      "x402": {
+        "status": "neutral",
+        "message": "x402 payment protocol not detected (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /",
+            "request": {
+              "url": "https://vet24cr.com/",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "text/html",
+                "link": "</.well-known/api-catalog>; rel=\"api-catalog\", </api/openapi.json>; rel=\"service-desc\", </api/readme.md>; rel=\"service-doc\", </llms.txt>; rel=\"describedby\"",
+                "cf-ray": "a36ef125085f7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/ returned 200 (not 402)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /api",
+            "request": {
+              "url": "https://vet24cr.com/api",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef125286d7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/api returned 404 (not 402)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /api/v1",
+            "request": {
+              "url": "https://vet24cr.com/api/v1",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef125286e7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/api/v1 returned 404 (not 402)"
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET /platform/v2/x402/discovery/resources",
+            "request": {
+              "url": "https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources?limit=500",
+              "method": "GET"
+            },
+            "response": {
+              "status": 200,
+              "statusText": "OK",
+              "headers": {
+                "content-type": "application/json",
+                "cf-ray": "a36ef125085e7df0-SJO"
+              }
+            }
+          },
+          {
+            "action": "fetch",
+            "label": "GET Bazaar discovery API",
+            "request": {
+              "url": "https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources?limit=500",
+              "method": "GET"
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Network error querying Bazaar API"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "x402 payment protocol not detected"
+            }
+          }
+        ],
+        "durationMs": 1010
+      },
+      "mpp": {
+        "status": "neutral",
+        "message": "MPP payment discovery not detected (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /openapi.json",
+            "request": {
+              "url": "https://vet24cr.com/openapi.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef12518667df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "neutral",
+              "summary": "/openapi.json returned 404"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "MPP payment discovery not detected"
+            }
+          }
+        ],
+        "durationMs": 52
+      },
+      "ucp": {
+        "status": "neutral",
+        "message": "UCP profile not found (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/ucp",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/ucp",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef125085d7df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- UCP profile not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "UCP profile not found"
+            }
+          }
+        ],
+        "durationMs": 50
+      },
+      "acp": {
+        "status": "neutral",
+        "message": "ACP discovery document not found (not a commerce site)",
+        "evidence": [
+          {
+            "action": "fetch",
+            "label": "GET /.well-known/acp.json",
+            "request": {
+              "url": "https://vet24cr.com/.well-known/acp.json",
+              "method": "GET"
+            },
+            "response": {
+              "status": 404,
+              "statusText": "Not Found",
+              "headers": {
+                "content-type": "text/html",
+                "cf-ray": "a36ef12528697df0-SJO"
+              }
+            },
+            "finding": {
+              "outcome": "negative",
+              "summary": "Server returned 404 -- ACP discovery document not found"
+            }
+          },
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "ACP discovery document not found"
+            }
+          }
+        ],
+        "durationMs": 71
+      },
+      "ap2": {
+        "status": "neutral",
+        "message": "AP2 not detected (no A2A Agent Card) (not a commerce site)",
+        "evidence": [
+          {
+            "action": "conclude",
+            "label": "Conclusion",
+            "finding": {
+              "outcome": "negative",
+              "summary": "No A2A Agent Card found -- AP2 requires an A2A Agent Card"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "nextLevel": {
+    "target": 5,
+    "name": "Agent-Native",
+    "requirements": [
+      {
+        "check": "authMd",
+        "description": "Publish Auth.md metadata for agent registration",
+        "shortPrompt": "Serve /auth.md and advertise agent_auth in OAuth Authorization Server metadata so agents can register securely.",
+        "specUrls": [
+          "https://workos.com/auth-md",
+          "https://github.com/workos/auth.md"
+        ],
+        "prompt": "Serve /auth.md at the site root with agent registration instructions, publish /.well-known/oauth-protected-resource, and include an agent_auth block in /.well-known/oauth-authorization-server with register_uri, supported identity types, credential types, and claim/revocation URLs where applicable.",
+        "skillUrl": "https://isitagentready.com/.well-known/agent-skills/auth-md/SKILL.md"
+      },
+      {
+        "check": "mcpServerCard",
+        "description": "Publish an MCP Server Card for agent discovery",
+        "shortPrompt": "Serve an MCP Server Card (SEP-1649) at /.well-known/mcp/server-card.json with serverInfo, transport endpoint, and capabilities.",
+        "specUrls": [
+          "https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127"
+        ],
+        "prompt": "Serve an MCP Server Card (SEP-1649) at /.well-known/mcp/server-card.json with serverInfo (name, version), transport endpoint, and capabilities. The schema is being standardized at https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127",
+        "skillUrl": "https://isitagentready.com/.well-known/agent-skills/mcp-server-card/SKILL.md"
+      },
+      {
+        "check": "a2aAgentCard",
+        "description": "Publish an A2A Agent Card for agent-to-agent discovery",
+        "shortPrompt": "Serve an A2A Agent Card at /.well-known/agent-card.json with your agent name, version, supported interfaces, capabilities, and skills.",
+        "specUrls": [
+          "https://a2a-protocol.org/latest/specification/",
+          "https://a2a-protocol.org/latest/topics/agent-discovery/"
+        ],
+        "prompt": "Serve an A2A Agent Card (JSON) at /.well-known/agent-card.json describing your agent. Include name, version, description, supportedInterfaces (with service URL and transport protocol), capabilities, and skills (each with id, name, description). This enables other AI agents to discover and interact with your agent via the A2A protocol.",
+        "skillUrl": "https://isitagentready.com/.well-known/agent-skills/a2a-agent-card/SKILL.md"
+      },
+      {
+        "check": "agentSkills",
+        "description": "Publish an agent skills discovery index",
+        "shortPrompt": "Publish a skills index at /.well-known/agent-skills/index.json listing skill names, types, descriptions, URLs, and digests.",
+        "specUrls": [
+          "https://github.com/cloudflare/agent-skills-discovery-rfc",
+          "https://agentskills.io/"
+        ],
+        "prompt": "Publish a skills discovery index at /.well-known/agent-skills/index.json (per the Agent Skills Discovery RFC v0.2.0). Include a $schema field, and a skills array where each entry has name, type (\"skill-md\" or \"archive\"), description, url, and a sha256 digest for integrity verification.",
+        "skillUrl": "https://isitagentready.com/.well-known/agent-skills/agent-skills/SKILL.md"
+      }
+    ]
+  },
+  "isCommerce": false,
+  "commerceSignals": [
+    "url:/cart"
+  ]
+}


### PR DESCRIPTION
## Summary
Archiva la verificación productiva de AR3 (issue #15) tras el merge de PR #22 (`0da2cb8`):

- `production-verification.md` / `production-headers.txt`: los ocho `curl` solicitados contra `vet24cr.com` — negociación `Accept: text/markdown`, HEAD, mirrors directos con CORS/`noindex`, y HTML negociado sin heredar `noindex`.
- `api-report-incorrect.md`: confirma que `/api/report-incorrect/` sigue funcionando igual (POST no capturado por el nuevo `run_worker_first`).
- `scan-post-deploy.json`: escaneo completo post-despliegue (`scannedAt=2026-09-06T16:45:09.890Z`) — nivel 4 (Agent-Integrated), `markdownNegotiation=pass` sumado a los seis checks heredados de AR2.
- `scan-comparison.md`: comparativa pre/post y clasificación de los checks que no pasan.
- `ar3-06-auditoria-ia.md`: protocolo de auditoría con tres IAs — queda **explícitamente pendiente**, sin inventar respuestas, por falta de acceso a tres infraestructuras de búsqueda distintas en esta sesión.

## Alcance
Solo documentación/evidencia, seis archivos nuevos en `docs/agent-readiness/evidencia/ar3/`. No toca código de producto.

## Verificación de esta sesión
Comparé el JSON de `scan-post-deploy.json` contra `scan-pre-deploy.json` (ya en `main`): línea base y resultado consistentes, siete checks funcionales en `pass`, coincide con una captura de pantalla de isitagentready.com del propietario (nivel 4, score 47).

No cierro el issue #15 — falta AR3-06 (auditoría con tres IAs), que queda pendiente y documentada como tal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1yPvd9UaNksNZXqRdTosZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1yPvd9UaNksNZXqRdTosZ)_